### PR TITLE
Feature/multipart upload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3306,7 +3306,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3dlio"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,17 @@ As such, this project essentially has 3 components that can be utilized:
 ## What's New
 This is in reverse order, newest first.
 
+### Version 0.4.4
+Added a multi-part uploader.  This includes the ability to do so with zero buffer copies between Python and Rust.  This works by providing a function, that Rust executes and allocates the space for.  Python can then fill the memory region, and give it back to Rust.  This all occurs zero-copy with Rust managing lifetimes.  At this point, the memory region can be streamed to the S3 back-end, including using multi-part upload.  
+#### New Tests
+There are several new tests added, in the python/tests subdirectory, including:
+  - python/tests/multi-part_smoke.py
+  - python/tests/test_multipart_writer.py
+  - tests/test_multipart.rs
+
+#### New Docs
+There is also a new MultiPart_README.md file that explains all the options and how to use the multi part features in each library framework. 
+
 ### Version 0.4.3
 After many promises of a fully functional and compatible PyTorch data loader, I believe that version 0.4.3 provides it.  Or, at least something very similar and quite functional, as all functional compatability tests and comparisons to the aws s3torchconnector library seem to show parity.  
 Also we updated the Dockerfile to enable building containers again.  Likely more work is needed to slim down the image as its about 19 GB. 

--- a/docs/MultiPart_README.md
+++ b/docs/MultiPart_README.md
@@ -1,0 +1,225 @@
+# s3dlio Multipart Upload — Streaming, Zero‑Copy
+
+This document explains how to use the **streaming, concurrent multipart upload (MPU)** feature in s3dlio from both **Rust** and **Python**, with a focus on **zero‑copy** data paths and high throughput.
+
+> TL;DR — For best performance, use the **`reserve()` / `commit()`** API in Python (true zero‑copy into Rust), or call `write_blocking(&[u8])` / `write_owned_blocking(Vec<u8>)` in Rust. Close with `close()` / `finish_blocking()` to complete the MPU.
+
+---
+
+## Table of Contents
+
+* [Overview](#overview)
+* [S3 Requirements & Constraints](#s3-requirements--constraints)
+* [Configuration](#configuration)
+* [Rust API](#rust-api)
+
+  * [Quick start](#quick-start)
+  * [Full example](#full-example)
+* [Python API](#python-api)
+
+  * [Quick start (zero‑copy)](#quick-start-zero-copy)
+  * [Writing from bytes / memoryview / NumPy](#writing-from-bytes--memoryview--numpy)
+  * [PyTorch / JAX / TensorFlow notes](#pytorch--jax--tensorflow-notes)
+* [Advanced](#advanced)
+
+  * [Flushing partial parts](#flushing-partial-parts)
+  * [Aborting an MPU](#aborting-an-mpu)
+  * [Content type / metadata](#content-type--metadata)
+  * [Throughput tuning](#throughput-tuning)
+* [Operational guidance](#operational-guidance)
+* [FAQ](#faq)
+
+---
+
+## Overview
+
+`s3dlio` implements a **streaming, concurrent** S3 Multipart Upload pipeline. Large payloads are automatically split into parts and uploaded in parallel with bounded concurrency. The design goal is **multiple GB/s** of sustained throughput to local S3-compatible stores (e.g., MinIO or scale‑out S3 gateways).
+
+Key properties:
+
+* **Streaming**: no staging to temp files by default.
+* **Concurrent**: multiple in‑flight `UploadPart` calls, limited by a semaphore.
+* **Zero‑copy (Python)**: `reserve()` exposes a Rust‑owned buffer as a writable Python `memoryview`; `commit()` hands the buffer to the uploader without copying.
+* **Robust finish**: `close()` / `finish_blocking()` joins outstanding part tasks and issues `CompleteMultipartUpload`.
+
+---
+
+## S3 Requirements & Constraints
+
+* **Minimum part size**: 5 MiB for all parts except the final part.
+* **Number of parts**: up to 10,000 parts per object (standard S3 limits).
+* **Part ordering**: parts are numbered starting at 1; s3dlio handles ordering.
+* **ETag**: the final ETag often reflects a multipart hash; don’t treat it as MD5 of the whole object.
+
+---
+
+## Configuration
+
+`MultipartUploadConfig` (Rust) / keyword args (Python):
+
+* `part_size: usize` — Target size per part in bytes (default: 16 MiB). **Must be ≥ 5 MiB**.
+* `max_in_flight: usize` — Max concurrent `UploadPart` requests (default: 16).
+* `abort_on_drop: bool` — Best‑effort abort if the writer is dropped without finishing (default: true).
+* `content_type: Option<String>` — Optional `Content-Type` set at `CreateMultipartUpload`.
+
+---
+
+## Rust API
+
+### Quick start
+
+```rust
+use s3dlio::{MultipartUploadConfig, MultipartUploadSink};
+
+let cfg = MultipartUploadConfig { part_size: 32<<20, max_in_flight: 32, ..Default::default() };
+let mut w = MultipartUploadSink::new("my-bucket", "path/to/obj.bin", cfg)?;
+
+// Stream in chunks from your source
+for chunk in source_iter() {
+    w.write_blocking(&chunk)?;        // &[u8]
+}
+
+// Or hand over owned buffers to avoid extra copies in Rust
+// w.write_owned_blocking(chunk_vec)?; // Vec<u8>
+
+let info = w.finish_blocking()?;      // Complete MPU
+println!("uploaded {} bytes in {} parts", info.total_bytes, info.parts);
+```
+
+### Full example
+
+```rust
+use s3dlio::{MultipartUploadConfig, MultipartUploadSink};
+
+fn upload_example() -> anyhow::Result<()> {
+    let cfg = MultipartUploadConfig {
+        part_size: 32 * 1024 * 1024,   // 32 MiB
+        max_in_flight: 16,
+        content_type: Some("application/octet-stream".into()),
+        ..Default::default()
+    };
+    let mut w = MultipartUploadSink::new("my-bucket", "dir/checkpoint.bin", cfg)?;
+
+    // Write 65 MiB in 8 MiB slices; last < part_size is fine as final part
+    let block = 8 * 1024 * 1024;
+    let total = (64 * 1024 * 1024) + (1 * 1024 * 1024);
+    let pattern = vec![0xABu8; block];
+
+    let mut remaining = total;
+    while remaining >= block {
+        w.write_blocking(&pattern)?;
+        remaining -= block;
+    }
+    if remaining > 0 { w.write_blocking(&vec![0xAB; remaining])?; }
+
+    let info = w.finish_blocking()?;
+    println!("ETag={:?}, parts={}, bytes={}", info.e_tag, info.parts, info.total_bytes);
+    Ok(())
+}
+```
+
+---
+
+## Python API
+
+### Quick start (zero‑copy)
+
+```python
+from s3dlio import MultipartUploadWriter
+
+w = MultipartUploadWriter.from_uri(
+    "s3://my-bucket/dir/checkpoint.bin",
+    part_size=32<<20,
+    max_in_flight=16,
+)
+
+N = 64 * 1024 * 1024
+mv = w.reserve(N)      # Rust‑owned buffer → writable memoryview
+mv[:] = b"\xAB" * N   # Fill from Python without copying
+w.commit(N)            # Hand ownership to Rust uploader
+
+del mv                 # Don’t use mv after commit
+
+info = w.close()       # Complete MPU
+print(info)
+```
+
+### Writing from bytes / memoryview / NumPy
+
+* `write(data)` accepts any **bytes‑like** object (e.g., `bytes`, `bytearray`, `memoryview`, NumPy buffer). It copies **once** into Rust for ownership, then streams.
+* Large buffers (≥ 8 MiB) use an owned fast path internally to avoid additional copies; small buffers use a borrowed slice path.
+
+```python
+# bytes / bytearray
+w.write(b"\xCD" * (4 << 20))
+
+# memoryview on NumPy (C‑contiguous) — convenient, still one owning copy in Rust
+import numpy as np
+arr = np.zeros(32 << 20, dtype=np.uint8)
+w.write(memoryview(arr))
+```
+
+### PyTorch / JAX / TensorFlow notes
+
+* **Best performance** still comes from `reserve()` / `commit()`.
+* For **PyTorch (CPU, contiguous)**: `tensor.numpy()` is zero‑copy into NumPy; then use `memoryview` on that array.
+
+  ```python
+  import torch, numpy as np
+  t = torch.full((32 << 20,), 0xEE, dtype=torch.uint8, device='cpu').contiguous()
+  arr = t.numpy()  # view, no copy (CPU/contiguous)
+  w.write(memoryview(arr))
+  ```
+* **GPU tensors** require staging to host memory first (`.cpu()`), which will copy; prefer `reserve()/commit()` to avoid extra allocations.
+* **JAX/TF**: Ensure you have a CPU contiguous buffer (e.g., NumPy view) before calling `write()`.
+
+---
+
+## Advanced
+
+### Flushing partial parts
+
+`flush()` forces any buffered bytes to upload as a (possibly short) final part **without** finishing the MPU. Typically you don’t need this; `close()` will upload any tail automatically.
+
+### Aborting an MPU
+
+`abort()` cancels the upload and best‑effort cleans up the server state. After abort, the writer is unusable.
+
+### Content type / metadata
+
+You can set `content_type` on creation. Future versions may expose additional headers/metadata if needed.
+
+### Throughput tuning
+
+* **`part_size`**: 16–64 MiB works well; too small increases overhead, too large reduces concurrency benefits.
+* **`max_in_flight`**: 8–64 typical for fast local S3 backends. Watch endpoint’s concurrency limits.
+* Ensure your client and endpoint are on the same high‑bandwidth network; enable jumbo frames as appropriate.
+
+---
+
+## Operational guidance
+
+* **Don’t reuse** the memoryview returned by `reserve()` after `commit()`.
+* Ensure **contiguous** and **CPU‑resident** buffers when using `write()` with framework tensors.
+* Buckets/objects are created in whatever region/endpoint your s3dlio client is configured for (see project README for env vars).
+
+---
+
+## FAQ
+
+**Q: Do I have to use `reserve()`?**
+A: No. It’s the fastest path, but `write()` works with any bytes‑like object and is simpler.
+
+**Q: What happens if a part upload fails?**
+A: `close()` returns an error. You can call `abort()` to clean up. (A future version may auto‑abort on the first failure.)
+
+**Q: Can I stream more data after `close()`?**
+A: No. Create a new writer for another object.
+
+**Q: Minimum part size?**
+A: 5 MiB (S3 rule) for all but the final part.
+
+---
+
+*Last updated:* this document accompanies s3dlio ≥ 0.4.4 with streaming multipart upload support.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.4.3"
+version = "0.4.4"
 description = "A Python S3 library providing deep-learning I/O built in Rust"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/tests/multi-part_smoke.py
+++ b/python/tests/multi-part_smoke.py
@@ -1,0 +1,36 @@
+import s3dlio
+import os
+import shutil
+import time
+
+# --- Configuration ---
+BUCKET_NAME = "russ-test6"
+S3_URI = f"s3://{BUCKET_NAME}"
+#TEST_PREFIX = "test-multipart/"
+#S3_URI_PREFIX = f"s3://{BUCKET_NAME}/{TEST_PREFIX}"
+
+
+# Optional: dial up logs
+os.environ["RUST_LOG"] = "s3dlio=debug,aws_sdk_s3=info"
+
+location = f"{S3_URI}/test-multipart.bin"
+
+print(f"--- Creating S3 bucket {BUCKET_NAME}... ---")
+s3dlio.create_bucket(BUCKET_NAME)
+
+N = 64 * 1024 * 1024  # 64 MiB
+w = s3dlio.MultipartUploadWriter.from_uri(
+    location,
+    part_size = 32 << 20,
+    max_in_flight = 16,
+)
+
+# true zero-copy into Rust-owned buffer
+mv = w.reserve(N)
+mv[:] = b"\xAB" * N
+w.commit(N)
+del mv      # don’t use it again after commit
+
+info = w.close()
+print("MPU done:", info)
+

--- a/python/tests/test_multipart_writer.py
+++ b/python/tests/test_multipart_writer.py
@@ -1,0 +1,59 @@
+# python/tests/test_multipart_writer.py
+import os
+import time
+import unittest
+import s3dlio
+
+RUST_LOG = os.environ.get("RUST_LOG", "s3dlio=warn,aws_sdk_s3=warn")
+os.environ["RUST_LOG"] = RUST_LOG
+
+
+def unique_bucket(prefix="mpu-py"):
+    return f"{prefix}-{os.getpid()}-{int(time.time())}"
+
+class TestMultipartWriter(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.bucket = unique_bucket()
+        s3dlio.create_bucket(cls.bucket)
+
+    @classmethod
+    def tearDownClass(cls):
+        try:
+            s3dlio.delete_bucket(cls.bucket)
+        except Exception:
+            pass
+
+    def test_reserve_commit_zero_copy(self):
+        uri = f"s3://{self.bucket}/ckpt-zero-copy.bin"
+        N = (64 << 20) + (1 << 20)  # 65 MiB
+        w = s3dlio.MultipartUploadWriter.from_uri(uri, part_size=32<<20, max_in_flight=16)
+        mv = w.reserve(N)
+        mv[:] = b"\xAB" * N
+        w.commit(N)
+        del mv
+        info = w.close()
+        self.assertEqual(info["total_bytes"], N)
+        self.assertGreaterEqual(info["parts"], 2)
+        # Optional spot-check if get_range is available
+        try:
+            head = s3dlio.get_range(uri, 0, 16)
+            tail = s3dlio.get_range(uri, N - 16, 16)
+            self.assertEqual(bytes(head), b"\xAB" * 16)
+            self.assertEqual(bytes(tail), b"\xAB" * 16)
+        except Exception:
+            pass
+
+    def test_write_bytes_path(self):
+        uri = f"s3://{self.bucket}/ckpt-write.bin"
+        w = s3dlio.MultipartUploadWriter.from_uri(uri, part_size=16<<20, max_in_flight=8)
+        payload = b"\xCD" * (4 << 20)  # 4 MiB
+        for _ in range(10):
+            w.write(payload)
+        info = w.close()
+        self.assertEqual(info["total_bytes"], 10 * len(payload))
+        self.assertGreaterEqual(info["parts"], 1)
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,15 @@ pub use crate::s3_utils::{
     DEFAULT_OBJECT_SIZE,
 };
 
+mod multipart;
+
+// Re-export the multipart public types
+pub use crate::multipart::{
+    MultipartUploadConfig,
+    MultipartUploadSink,
+    MultipartCompleteInfo,
+};
+
 // types:
 pub use crate::config::ObjectType;
 

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -1,0 +1,468 @@
+// src/multipart.rs
+//
+// Streaming, concurrent Multipart Upload (MPU) for very large objects.
+// Keeps nearly all MPU logic self-contained in this module.
+//
+// Design:
+// - MultipartUploadConfig configures part sizing and concurrency.
+// - MultipartUploadSink provides a streaming writer API:
+//     - write(&[u8]) buffers until part_size and schedules concurrent UploadPart
+//     - finish() uploads any tail and issues CompleteMultipartUpload
+//     - abort() aborts the MPU; also runs on Drop if not finished and abort_on_drop
+//
+// Integrations:
+// - Uses the global Tokio runtime and S3 client from s3_client.rs
+// - Accepts "s3://bucket/key" via from_uri() using parse_s3_uri() from s3_utils.rs
+//
+// Notes:
+// - All public APIs return anyhow::Result to match the crate style.
+// - Logging hooks can be added later to feed s3_logger; kept minimal here.
+
+use anyhow::{Context, Result, bail};
+use aws_sdk_s3::Client;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
+use aws_sdk_s3::primitives::ByteStream;
+
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+/*
+use tokio::sync::{Semaphore, OwnedSemaphorePermit};
+use tokio::task::JoinSet;
+*/
+
+use std::sync::{Arc, Mutex};
+use std::time::SystemTime;
+
+use crate::s3_client::{aws_s3_client_async, run_on_global_rt};
+use crate::s3_utils::parse_s3_uri;
+
+#[derive(Clone, Debug)]
+pub struct MultipartUploadConfig {
+    /// Target size of each part in bytes (AWS minimum is 5 MiB, typical 8–64 MiB).
+    pub part_size: usize,
+    /// Maximum number of concurrent in-flight part uploads.
+    pub max_in_flight: usize,
+    /// Abort the MPU automatically if dropped unfinished.
+    pub abort_on_drop: bool,
+    /// Optional content-type to set on CreateMultipartUpload.
+    pub content_type: Option<String>,
+}
+
+impl Default for MultipartUploadConfig {
+    fn default() -> Self {
+        Self {
+            part_size: 16 * 1024 * 1024,   // 16 MiB
+            max_in_flight: 16,
+            abort_on_drop: true,
+            content_type: None,
+        }
+    }
+}
+
+/// Result info returned by finish()
+#[derive(Clone, Debug)]
+pub struct MultipartCompleteInfo {
+    pub e_tag: Option<String>,
+    pub total_bytes: u64,
+    pub parts: usize,
+    pub started_at: SystemTime,
+    pub completed_at: SystemTime,
+}
+
+
+/// Streaming sink for multipart upload.
+pub struct MultipartUploadSink {
+    client: Client,
+    bucket: String,
+    key: String,
+    upload_id: String,
+    cfg: MultipartUploadConfig,
+
+    // buffering
+    buf: Vec<u8>,
+    next_part_number: i32,
+    total_bytes: u64,
+    started_at: SystemTime,
+
+    // concurrency
+    sem: Arc<Semaphore>,
+    tasks: Vec<JoinHandle<Result<(i32, String)>>>, // spawned on global runtime
+    completed: Arc<Mutex<Vec<(i32, String)>>>,
+
+    finished: bool,
+}
+
+impl Drop for MultipartUploadSink {
+    fn drop(&mut self) {
+        if self.finished || !self.cfg.abort_on_drop {
+            return;
+        }
+        // Best effort abort; we can't async .await here. Fire-and-forget via runtime.
+        let client = self.client.clone();
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let upload_id = self.upload_id.clone();
+        let _ = run_on_global_rt(async move {
+            let _ = client.abort_multipart_upload()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(upload_id)
+                .send()
+                .await;
+            Ok::<_, anyhow::Error>(())
+        });
+    }
+}
+
+impl MultipartUploadSink {
+    /// Create a new MPU sink from an "s3://bucket/key" URI.
+    pub fn from_uri(uri: &str, cfg: MultipartUploadConfig) -> Result<Self> {
+        let (b, k) = parse_s3_uri(uri)?;
+        Self::new(&b, &k, cfg)
+    }
+
+    /// Create a new MPU sink for bucket + key.
+    pub fn new(bucket: &str, key: &str, cfg: MultipartUploadConfig) -> Result<Self> {
+        let bucket = bucket.to_string();
+        let key = key.to_string();
+        run_on_global_rt(async move { Self::new_async(&bucket, &key, cfg).await })
+    }
+
+    /// Async constructor: issues CreateMultipartUpload.
+    pub async fn new_async(bucket: &str, key: &str, cfg: MultipartUploadConfig) -> Result<Self> {
+        if cfg.part_size < 5 * 1024 * 1024 {
+            bail!("part_size must be at least 5 MiB for S3 Multipart Upload");
+        }
+        if cfg.max_in_flight == 0 {
+            bail!("max_in_flight must be >= 1");
+        }
+    
+        let client = aws_s3_client_async().await?;
+        let mut req = client.create_multipart_upload()
+            .bucket(bucket)
+            .key(key);
+        if let Some(ct) = &cfg.content_type {
+            req = req.content_type(ct);
+        }
+        let resp = req.send().await.context("CreateMultipartUpload failed")?;
+        let upload_id = resp.upload_id().unwrap_or_default().to_string();
+        if upload_id.is_empty() {
+            bail!("CreateMultipartUpload returned empty upload_id");
+        }
+    
+        // Build semaphore BEFORE moving cfg into the struct.
+        let sem = Arc::new(Semaphore::new(cfg.max_in_flight));
+    
+        Ok(Self {
+            client,
+            bucket: bucket.to_string(),
+            key: key.to_string(),
+            upload_id,
+            cfg, // moved exactly once here
+            buf: Vec::with_capacity(2 * 1024 * 1024),
+            next_part_number: 1,
+            total_bytes: 0,
+            started_at: SystemTime::now(),
+            sem,
+            tasks: Vec::new(),
+            completed: Arc::new(Mutex::new(Vec::new())),
+            finished: false,
+        })
+    }
+
+    /// Blocking write from a borrowed slice (no async needed), but do we want run_on_global_rt ?
+    pub fn write_blocking(&mut self, data: &[u8]) -> Result<()> {
+        // Fast path: if internal buffer is empty and data is already large,
+        // cut directly into full-size parts to avoid extra buffering.
+        if self.buf.is_empty() && data.len() >= self.cfg.part_size {
+            let mut offset = 0usize;
+            while data.len() - offset >= self.cfg.part_size {
+                let end = offset + self.cfg.part_size;
+                let chunk = data[offset..end].to_vec(); // own the part buffer
+                offset = end;
+                self.spawn_part(chunk)?;
+            }
+            if offset < data.len() {
+                self.buf.extend_from_slice(&data[offset..]);
+            }
+            self.total_bytes += data.len() as u64;
+            return Ok(());
+        }
+
+        // Otherwise merge into internal buffer and emit parts as thresholds are crossed.
+        self.buf.extend_from_slice(data);
+        self.total_bytes += data.len() as u64;
+        while self.buf.len() >= self.cfg.part_size {
+            let chunk = self.buf.drain(..self.cfg.part_size).collect::<Vec<u8>>();
+            self.spawn_part(chunk)?;
+        }
+        Ok(())
+    }
+
+
+    /// Async write: buffers and schedules part uploads as needed.
+    pub async fn write(&mut self, data: Vec<u8>) -> Result<()> {
+        self.total_bytes += data.len() as u64;
+
+        if self.buf.is_empty() && data.len() >= self.cfg.part_size {
+            // Fast path: directly slice full-sized parts out of data to avoid extra copies.
+            let mut offset = 0usize;
+            while data.len() - offset >= self.cfg.part_size {
+                let end = offset + self.cfg.part_size;
+                let chunk = data[offset..end].to_vec();
+                offset = end;
+                self.spawn_part(chunk)?;
+            }
+            // Remainder goes into internal buffer.
+            if offset < data.len() {
+                self.buf.extend_from_slice(&data[offset..]);
+            }
+        } else {
+            // Slow path: fill buffer until it reaches part_size
+            self.buf.extend_from_slice(&data);
+            while self.buf.len() >= self.cfg.part_size {
+                let chunk = self.buf.drain(..self.cfg.part_size).collect::<Vec<u8>>();
+                self.spawn_part(chunk)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Zero-copy path: accept an *owned* buffer and stream without copying.
+    /// This is equivalent to `write()` but consumes `data` directly.
+    /// Zero-copy within Rust: accept an owned Vec from Python and stream without another copy,
+    /// what about run_on_global_rt() ?
+    pub fn write_owned_blocking(&mut self, data: Vec<u8>) -> Result<()> {
+        if self.buf.is_empty() && data.len() >= self.cfg.part_size {
+            let mut offset = 0usize;
+            while data.len() - offset >= self.cfg.part_size {
+                let end = offset + self.cfg.part_size;
+                let chunk = data[offset..end].to_vec(); // own each part buffer
+                offset = end;
+                self.spawn_part(chunk)?;
+            }
+            if offset < data.len() {
+                self.buf.extend_from_slice(&data[offset..]);
+            }
+        } else {
+            self.buf.extend_from_slice(&data);
+            while self.buf.len() >= self.cfg.part_size {
+                let chunk = self.buf.drain(..self.cfg.part_size).collect::<Vec<u8>>();
+                self.spawn_part(chunk)?;
+            }
+        }
+    
+        self.total_bytes += data.len() as u64;
+        Ok(())
+    }
+
+
+    /// Async version of `write_owned_blocking`.
+    pub async fn write_owned(&mut self, data: Vec<u8>) -> Result<()> {
+        self.total_bytes += data.len() as u64;
+
+        if self.buf.is_empty() && data.len() >= self.cfg.part_size {
+            // Fast path: slice full-sized parts out of `data` without extra copies.
+            let mut offset = 0usize;
+            while data.len() - offset >= self.cfg.part_size {
+                let end = offset + self.cfg.part_size;
+                // Move out chunks by allocating a new Vec and copying the slice.
+                // (No extra Python->Rust copy; the only copy is within Rust when chunking `data`.)
+                let chunk = data[offset..end].to_vec();
+                offset = end;
+                self.spawn_part(chunk)?;
+            }
+            if offset < data.len() {
+                // Move the tail into internal buffer.
+                self.buf.extend_from_slice(&data[offset..]);
+            }
+        } else {
+            // Merge into internal buffer; will spawn parts as it crosses thresholds.
+            self.buf.extend_from_slice(&data);
+            while self.buf.len() >= self.cfg.part_size {
+                let chunk = self.buf.drain(..self.cfg.part_size).collect::<Vec<u8>>();
+                self.spawn_part(chunk)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Flush any buffered data as a (possibly short) part without finishing the MPU.
+    pub fn flush_blocking(&mut self) -> Result<()> {
+        if !self.buf.is_empty() {
+            let chunk = std::mem::take(&mut self.buf);
+            self.spawn_part(chunk)?;
+        }
+        Ok(())
+    }
+
+
+    pub async fn flush(&mut self) -> Result<()> {
+        if !self.buf.is_empty() {
+            let chunk = std::mem::take(&mut self.buf);
+            self.spawn_part(chunk)?;
+        }
+        Ok(())
+    }
+
+
+    pub fn finish_blocking(&mut self) -> Result<MultipartCompleteInfo> {
+        if self.finished {
+            bail!("finish() called more than once");
+        }
+        // Upload any tail synchronously
+        if !self.buf.is_empty() {
+            let chunk = std::mem::take(&mut self.buf);
+            self.spawn_part(chunk)?;
+        }
+    
+        // Move the JoinHandles out so the future owns them (no borrow of self).
+        let tasks = std::mem::take(&mut self.tasks);
+    
+        // Await all part tasks on the global runtime
+        let results: Vec<(i32, String)> = run_on_global_rt(async move {
+            let mut out = Vec::with_capacity(tasks.len());
+            for h in tasks {
+                // First await the join handle, then unwrap the inner Result
+                let res = h.await.context("part task join failed")??;
+                out.push(res);
+            }
+            Ok::<_, anyhow::Error>(out)
+        })?;
+    
+        // Record completed parts
+        {
+            let mut guard = self.completed.lock().unwrap();
+            guard.extend(results);
+        }
+    
+        // Build CompletedMultipartUpload
+        let mut parts = self.completed.lock().unwrap().clone();
+        parts.sort_by_key(|(pn, _)| *pn);
+        let completed_parts: Vec<CompletedPart> = parts
+            .into_iter()
+            .map(|(pn, etag)| {
+                CompletedPart::builder()
+                    .set_e_tag(Some(etag))
+                    .set_part_number(Some(pn))
+                    .build()
+            })
+            .collect();
+    
+        let cmu = CompletedMultipartUpload::builder()
+            .set_parts(Some(completed_parts))
+            .build();
+    
+        // Clone small fields; call CompleteMultipartUpload on the runtime.
+        let client = self.client.clone();
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let upload_id = self.upload_id.clone();
+    
+        let resp = run_on_global_rt(async move {
+            client
+                .complete_multipart_upload()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(upload_id)
+                .multipart_upload(cmu)
+                .send()
+                .await
+                .context("CompleteMultipartUpload failed")
+        })?;
+    
+        self.finished = true;
+    
+        Ok(MultipartCompleteInfo {
+            e_tag: resp.e_tag.map(|s| s.to_string()),
+            total_bytes: self.total_bytes,
+            parts: self.next_part_number.saturating_sub(1) as usize,
+            started_at: self.started_at,
+            completed_at: SystemTime::now(),
+        })
+    }
+
+
+    pub fn abort_blocking(&mut self) -> Result<()> {
+        // Move JoinHandles out so the future owns them
+        let tasks = std::mem::take(&mut self.tasks);
+    
+        // Best-effort: join and ignore results
+        let _ = run_on_global_rt(async move {
+            for h in tasks {
+                let _ = h.await;
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+    
+        // Abort MPU
+        let client = self.client.clone();
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let upload_id = self.upload_id.clone();
+    
+        let _ = run_on_global_rt(async move {
+            let _ = client
+                .abort_multipart_upload()
+                .bucket(bucket)
+                .key(key)
+                .upload_id(upload_id)
+                .send()
+                .await;
+            Ok::<_, anyhow::Error>(())
+        });
+    
+        self.finished = true;
+        Ok(())
+    }
+
+
+
+    fn spawn_part(&mut self, bytes: Vec<u8>) -> Result<()> {
+        let part_number = self.next_part_number;
+        self.next_part_number += 1;
+    
+        let client = self.client.clone();
+        let bucket = self.bucket.clone();
+        let key = self.key.clone();
+        let upload_id = self.upload_id.clone();
+        let semaphore = self.sem.clone();
+    
+        // Spawn the task *on the global Tokio runtime* and capture the JoinHandle.
+        let handle: JoinHandle<Result<(i32, String)>> = run_on_global_rt(async move {
+            // Spawn a child task on the same runtime; return its JoinHandle
+            let h = tokio::spawn(async move {
+                // Concurrency permit
+                let _permit = semaphore.acquire_owned().await.expect("semaphore closed");
+    
+                let body = ByteStream::from(bytes);
+                let resp = client
+                    .upload_part()
+                    .bucket(bucket)
+                    .key(key)
+                    .upload_id(upload_id)
+                    .part_number(part_number)
+                    .body(body)
+                    .send()
+                    .await
+                    .context("UploadPart failed")?;
+    
+                let etag = resp.e_tag().unwrap_or_default().to_string();
+                if etag.is_empty() {
+                    bail!("UploadPart returned empty ETag");
+                }
+                Ok::<(i32, String), anyhow::Error>((part_number, etag))
+            });
+            Ok::<_, anyhow::Error>(h)
+        })?;
+    
+        // Store handle to await later in finish_blocking()
+        self.tasks.push(handle);
+        Ok(())
+    }
+    
+    
+}
+    
+    
+    

--- a/src/python_api.rs
+++ b/src/python_api.rs
@@ -12,11 +12,18 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use pyo3::prelude::*;
-use pyo3::types::{PyAny, PyAnyMethods, PyBytes, PyDict, PyDictMethods, PyList};
+use pyo3::ffi;
+use std::os::raw::c_char;
+use pyo3::types::{PyAny, PyAnyMethods, 
+    PyBytes, PyBytesMethods, 
+    PyDict, PyDictMethods, 
+    PyList};
+use pyo3::{PyObject, Bound};
 use pyo3::exceptions::{PyRuntimeError, PyStopAsyncIteration};
 use pyo3::conversion::IntoPyObjectExt;
-
 use pyo3_async_runtimes::tokio::future_into_py; // only for bridge → Python
+                                                
+use futures_util::StreamExt;
 use tokio::{
     task,
     sync::{mpsc, Mutex},
@@ -56,7 +63,12 @@ use crate::data_loader::{
     s3_bytes::S3BytesDataset, //Only if required
 };
 
-use futures_util::StreamExt;
+use crate::multipart::{
+    MultipartUploadConfig,
+    MultipartUploadSink,
+};
+
+
 
 // ---------------------------------------------------------------------------
 // Logging helpers
@@ -701,6 +713,284 @@ impl PyAsyncDataLoaderIter {
 }
 
 // ---------------------------------------------------------------------------
+// Multipart upload code 
+// ---------------------------------------------------------------------------
+/// Streaming S3 multipart uploader.
+///
+/// - Fully streaming (no temp files by default)
+/// - Concurrent UploadPart with bounded in-flight concurrency
+/// - **Zero-copy** path via `reserve(size)` → fill memoryview → `commit(nbytes)`
+///
+/// Prefer the `reserve()` / `commit()` path for maximum throughput.
+/// Use `write()` as a convenient general path for any bytes-like object.
+#[pyclass(name = "MultipartUploadWriter", module = "s3dlio")]
+pub struct PyMultipartUploadWriter {
+    inner: Option<MultipartUploadSink>,
+    pending_buf: Option<Vec<u8>>, // Rust-owned buffer between reserve() and commit()
+}
+
+#[pymethods]
+impl PyMultipartUploadWriter {
+    /// Create a writer for `bucket` + `key`.
+    ///
+    /// Args:
+    ///     bucket: S3 bucket name (string)
+    ///     key: object key (string)
+    ///     part_size: target part size in bytes (>= 5 MiB). Default 16 MiB.
+    ///     max_in_flight: max concurrent part uploads. Default 16.
+    ///     content_type: optional Content-Type for the object.
+    ///     abort_on_drop: auto-abort if the writer is dropped without close(). Default True.
+    #[new]
+    #[pyo3(signature = (bucket, key, part_size=None, max_in_flight=None, content_type=None, abort_on_drop=None))]
+    fn new(
+        bucket: &str,
+        key: &str,
+        part_size: Option<usize>,
+        max_in_flight: Option<usize>,
+        content_type: Option<String>,
+        abort_on_drop: Option<bool>,
+    ) -> PyResult<Self> {
+        let mut cfg = MultipartUploadConfig::default();
+        if let Some(ps) = part_size { cfg.part_size = ps; }
+        if let Some(mif) = max_in_flight { cfg.max_in_flight = mif; }
+        if let Some(ct) = content_type { cfg.content_type = Some(ct); }
+        if let Some(aod) = abort_on_drop { cfg.abort_on_drop = aod; }
+
+        let inner = MultipartUploadSink::new(bucket, key, cfg)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Multipart init failed: {e}")))?;
+        Ok(Self { inner: Some(inner), pending_buf: None })
+    }
+
+    /// Create a writer from an `s3://bucket/key` URI.
+    ///
+    /// Args:
+    ///     uri: e.g. "s3://my-bucket/dir/obj.bin"
+    ///     part_size, max_in_flight, content_type, abort_on_drop: see `__init__`.
+    #[staticmethod]
+    #[pyo3(signature = (uri, part_size=None, max_in_flight=None, content_type=None, abort_on_drop=None))]
+    fn from_uri(
+        uri: &str,
+        part_size: Option<usize>,
+        max_in_flight: Option<usize>,
+        content_type: Option<String>,
+        abort_on_drop: Option<bool>,
+    ) -> PyResult<Self> {
+        let mut cfg = MultipartUploadConfig::default();
+        if let Some(ps) = part_size { cfg.part_size = ps; }
+        if let Some(mif) = max_in_flight { cfg.max_in_flight = mif; }
+        if let Some(ct) = content_type { cfg.content_type = Some(ct); }
+        if let Some(aod) = abort_on_drop { cfg.abort_on_drop = aod; }
+
+        let inner = MultipartUploadSink::from_uri(uri, cfg)
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("Multipart init failed: {e}")))?;
+        Ok(Self { inner: Some(inner), pending_buf: None })
+    }
+
+    /// Write a bytes-like object (bytes, bytearray, memoryview, NumPy buffer).
+    ///
+    /// For large buffers (>= 8 MiB), uses an owned fast path internally to avoid
+    /// extra copies. For maximum performance, prefer `reserve()`/`commit()`.
+    ///
+    /// Returns:
+    ///     int: number of bytes accepted.
+    #[pyo3(text_signature = "(self, data, /)")]
+    fn write<'py>(&mut self, py: Python<'py>, data: &Bound<'py, PyAny>) -> PyResult<usize> {
+        let inner = self.inner.as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("writer is closed"))?;
+
+        const OWNED_THRESHOLD: usize = 8 * 1024 * 1024; // 8 MiB
+
+        // 1) Fast path for any buffer-protocol object (NumPy, memoryview, bytearray, etc.)
+        if let Ok(buf) = data.extract::<pyo3::buffer::PyBuffer<u8>>() {
+            let len = buf.len_bytes();
+            let mut vec = Vec::<u8>::with_capacity(len);
+            unsafe { vec.set_len(len); }
+            buf.copy_to_slice(py, &mut vec[..])
+                .map_err(|e| PyRuntimeError::new_err(format!("buffer copy failed: {e}")))?;
+    
+            let res = if len >= OWNED_THRESHOLD {
+                py.allow_threads(|| inner.write_owned_blocking(vec))
+            } else {
+                py.allow_threads(|| inner.write_blocking(&vec))
+            };
+            return res
+                .map(|_| len)
+                .map_err(|e| PyRuntimeError::new_err(format!("write failed: {e}")));
+        }
+    
+        // 2) Fallback for plain bytes objects
+        if let Ok(bytes) = data.downcast::<PyBytes>() {
+            let slice = bytes.as_bytes(); // needs PyBytesMethods import
+            let len = slice.len();
+            if len >= OWNED_THRESHOLD {
+                let vec = slice.to_vec();
+                let res = py.allow_threads(|| inner.write_owned_blocking(vec));
+                return res
+                    .map(|_| len)
+                    .map_err(|e| PyRuntimeError::new_err(format!("write failed: {e}")));
+            } else {
+                let res = py.allow_threads(|| inner.write_blocking(slice));
+                return res
+                    .map(|_| len)
+                    .map_err(|e| PyRuntimeError::new_err(format!("write failed: {e}")));
+            }
+        }
+    
+        Err(pyo3::exceptions::PyTypeError::new_err(
+            "write() expects bytes-like (bytes, bytearray, memoryview, NumPy buffer)",
+        ))
+    }
+
+    /// Reserve a Rust-owned buffer and return a writable Python `memoryview`.
+    ///
+    /// Fill the memoryview in Python, then call `commit(nbytes)`. Do not reuse
+    /// the memoryview after `commit()`. Only one pending buffer is allowed.
+    ///
+    /// Args:
+    ///     size: number of bytes to reserve
+    ///
+    /// Returns:
+    ///     memoryview: writable view into the reserved buffer
+    #[pyo3(text_signature = "(self, size, /)")]
+    fn reserve(&mut self, py: Python<'_>, size: usize) -> PyResult<PyObject> {
+        // Disallow overlapping reserves
+        if self.pending_buf.is_some() {
+            return Err(PyRuntimeError::new_err(
+                "reserve() called while a previous buffer is pending; call commit() first",
+            ));
+        }
+
+        // reserve(): treat size==0 as no-op (avoids odd memoryviews)
+        if size == 0 {
+            self.pending_buf = Some(Vec::new());
+            // Return a 0-length memoryview (still legal)
+            let ptr = std::ptr::null_mut::<std::os::raw::c_char>();
+            let mv_ptr = unsafe { pyo3::ffi::PyMemoryView_FromMemory(ptr, 0, pyo3::ffi::PyBUF_WRITE) };
+            if mv_ptr.is_null() { return Err(PyErr::fetch(py)); }
+            return Ok(unsafe { PyObject::from_owned_ptr(py, mv_ptr) });
+        }
+    
+        // Allocate Rust-owned buffer and keep it alive in self.pending_buf so the
+        // memoryview's pointer stays valid until commit() (or close/abort).
+        let mut buf = vec![0u8; size];
+    
+        // Create a writable memoryview that points directly at our Vec's memory.
+        // Safety:
+        // - We pass a valid pointer/length for the Vec.
+        // - We keep the Vec alive (self.pending_buf = Some(buf)) so the memory doesn't move.
+        // - We won't reallocate this Vec (we never push; commit() only shrinks len).
+        let ptr = buf.as_mut_ptr() as *mut c_char;
+        let len = buf.len() as ffi::Py_ssize_t;
+        let flags = ffi::PyBUF_WRITE; // writable view
+    
+        let mv_ptr = unsafe { ffi::PyMemoryView_FromMemory(ptr, len, flags) };
+        if mv_ptr.is_null() {
+            // Convert the current Python error (if any) into a PyErr.
+            return Err(PyErr::fetch(py));
+        }
+    
+        // Convert the owned PyObject* into a safe PyObject handle.
+        let mv = unsafe { PyObject::from_owned_ptr(py, mv_ptr) };
+    
+        // Stash the Vec; this guarantees the pointer remains valid until commit().
+        self.pending_buf = Some(buf);
+        Ok(mv)
+    }
+
+
+
+    /// Commit the previously reserved buffer.
+    ///
+    /// Args:
+    ///     nbytes: number of bytes actually written into the reserved buffer
+    ///
+    /// Errors if `nbytes` exceeds the reserved size or if no buffer is pending.
+    #[pyo3(text_signature = "(self, nbytes, /)")]
+    fn commit(&mut self, py: Python<'_>, nbytes: usize) -> PyResult<()> {
+        let inner = self.inner.as_mut()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("writer is closed"))?;
+        let mut buf = self.pending_buf.take()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("no pending buffer; call reserve() first"))?;
+        if nbytes > buf.len() {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                format!("commit(nbytes={nbytes}) exceeds reserved size {}", buf.len()),
+            ));
+        }
+        unsafe { buf.set_len(nbytes); }
+        py.allow_threads(|| inner.write_owned_blocking(buf))
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("commit failed: {e}")))
+    }
+
+    /// Flush any buffered bytes as a (possibly short) part without finishing.
+    ///
+    /// Typically not required; `close()` will upload any tail automatically.
+    #[pyo3(text_signature = "(self)")]
+    fn flush(&mut self, py: Python<'_>) -> PyResult<()> {
+        let inner = self.inner.as_mut()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("writer is closed"))?;
+        py.allow_threads(|| inner.flush_blocking())
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("flush failed: {e}")))
+    }
+
+    /// Complete the multipart upload and close the writer.
+    ///
+    /// Returns:
+    ///     dict: {
+    ///        'etag': str or None,
+    ///        'total_bytes': int,
+    ///        'parts': int,
+    ///        'started_at': float (unix seconds),
+    ///        'completed_at': float (unix seconds)
+    ///     }
+    #[pyo3(text_signature = "(self)")]
+    fn close(&mut self, py: Python<'_>) -> PyResult<PyObject> {
+        let inner = self.inner.take()
+            .ok_or_else(|| pyo3::exceptions::PyRuntimeError::new_err("writer already closed"))?;
+        let info = py.allow_threads(|| { let mut owned = inner; owned.finish_blocking() })
+            .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("finish failed: {e}")))?;
+        let dict = PyDict::new(py);
+        if let Some(etag) = info.e_tag { dict.set_item("etag", etag).ok(); }
+        dict.set_item("total_bytes", info.total_bytes).ok();
+        dict.set_item("parts", info.parts).ok();
+        let started = info.started_at.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs_f64();
+        let completed = info.completed_at.duration_since(std::time::UNIX_EPOCH).unwrap_or_default().as_secs_f64();
+        dict.set_item("started_at", started).ok();
+        dict.set_item("completed_at", completed).ok();
+        Ok(dict.into())
+    }
+
+    /// Abort the multipart upload and close the writer.
+    ///
+    /// Best effort: outstanding tasks are joined and the MPU is aborted.
+    /// After abort, the writer is unusable.
+    #[pyo3(text_signature = "(self)")]
+    fn abort(&mut self, py: Python<'_>) -> PyResult<()> {
+        if let Some(mut inner) = self.inner.take() {
+            py.allow_threads(|| inner.abort_blocking())
+                .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("abort failed: {e}")))?;
+        }
+        Ok(())
+    }
+
+    /// Context manager enter: returns the writer.
+    #[pyo3(text_signature = "(self)")]
+    fn __enter__<'py>(slf: PyRefMut<'py, Self>) -> PyResult<PyRefMut<'py, Self>> { Ok(slf) }
+
+    /// Context manager exit: closes on success; aborts on exception.
+    #[pyo3(text_signature = "(self, exc_type, exc, tb)")]
+    fn __exit__(&mut self, py: Python<'_>, _t: PyObject, _v: PyObject, _tb: PyObject) -> PyResult<()> {
+        if self.inner.is_some() {
+            if let Some(mut inner) = self.inner.take() {
+                if let Err(_e) = py.allow_threads(|| inner.finish_blocking()) {
+                    let _ = py.allow_threads(|| inner.abort_blocking());
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Sub‑module exposed at crate‑root (`lib.rs` re‑exports it as needed)
 // ---------------------------------------------------------------------------
 #[pymodule]
@@ -737,6 +1027,10 @@ pub fn _pymod(m: &Bound<PyModule>) -> PyResult<()> {
     m.add_class::<PyAsyncDataLoaderIter>()?;
     m.add_class::<PyS3Dataset>()?;
     m.add_class::<PyS3AsyncDataLoader>()?;
+
+    // Checkpoint writer
+    m.add_class::<PyMultipartUploadWriter>()?;
+
     Ok(())
 }
 

--- a/tests/test_dataloader.rs
+++ b/tests/test_dataloader.rs
@@ -144,21 +144,20 @@ async fn iterable_dataset() {
     assert_eq!(collected, (0..55).collect::<Vec<_>>());
 }
 
+
 #[tokio::test]
 async fn unknown_len_dataset() {
     let ds = UnknownLenDataset { n: 10 };
-    let loader = DataLoader::new(
-        ds,
-        LoaderOptions {
-            batch_size: 3,
-            drop_last: false,
-            shuffle: false,
-            seed: 0,
-            num_workers: 0,
-            prefetch: 0,
-            auto_tune: false,
-        },
-    );
+
+    // Use builder-style options to avoid breakage when LoaderOptions grows fields.
+    let opts = LoaderOptions::default()
+        .with_batch_size(3)
+        .drop_last(false)
+        .shuffle(false, 0)
+        .num_workers(0)
+        .prefetch(0);
+
+    let loader = DataLoader::new(ds, opts);
 
     let collected: Vec<_> = loader
         .stream()

--- a/tests/test_multipart.rs
+++ b/tests/test_multipart.rs
@@ -1,0 +1,107 @@
+// tests/test_multipart.rs
+use anyhow::{Context, Result, ensure};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use s3dlio::{MultipartUploadConfig, MultipartUploadSink};
+use s3dlio::s3_client::{aws_s3_client_async, run_on_global_rt};
+
+fn unique(prefix: &str) -> String {
+    let pid = std::process::id();
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+    format!("s3dlio-{}-{}-{}", prefix, pid, now)
+}
+
+#[test]
+fn multipart_upload_basic() -> Result<()> {
+    let bucket = unique("mpu-basic");
+    let key = "test-mpu.bin";
+
+    // Create bucket
+    run_on_global_rt({
+        let bucket = bucket.clone();
+        async move {
+            let client = aws_s3_client_async().await?;
+            client.create_bucket().bucket(&bucket).send().await
+                .context("create_bucket")?;
+            Ok::<(), anyhow::Error>(())
+        }
+    })?;
+
+    // Upload ~65 MiB in 8 MiB writes
+    let cfg = MultipartUploadConfig { part_size: 32 * 1024 * 1024, max_in_flight: 8, ..Default::default() };
+    let mut sink = MultipartUploadSink::new(&bucket, key, cfg)?;
+
+    let total = (64 * 1024 * 1024) + (3 * 1024 * 1024);
+    let block = 8 * 1024 * 1024;
+    let pattern = vec![0xABu8; block];
+
+    let mut remaining = total;
+    while remaining >= block {
+        sink.write_blocking(&pattern)?;
+        remaining -= block;
+    }
+    if remaining > 0 {
+        sink.write_blocking(&vec![0xAB; remaining])?;
+    }
+
+    let info = sink.finish_blocking()?;
+    assert_eq!(info.total_bytes as usize, total, "total bytes mismatch");
+    assert!(info.parts >= 2, "expected >=2 parts, got {}", info.parts);
+
+    // HEAD to verify size, then cleanup
+    run_on_global_rt({
+        let bucket = bucket.clone();
+        let key = key.to_string();
+        async move {
+            let client = aws_s3_client_async().await?;
+            let head = client.head_object().bucket(&bucket).key(&key).send().await?;
+            let size = head.content_length().unwrap_or_default();
+            ensure!(size == total as i64, "HEAD size mismatch: {} vs {}", size, total);
+            let _ = client.delete_object().bucket(&bucket).key(&key).send().await;
+            let _ = client.delete_bucket().bucket(&bucket).send().await;
+            Ok::<(), anyhow::Error>(())
+        }
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn multipart_upload_abort() -> Result<()> {
+    let bucket = unique("mpu-abort");
+    let key = "abort.bin";
+
+    // Create bucket
+    run_on_global_rt({
+        let bucket = bucket.clone();
+        async move {
+            let client = aws_s3_client_async().await?;
+            client.create_bucket().bucket(&bucket).send().await
+                .context("create_bucket")?;
+            Ok::<(), anyhow::Error>(())
+        }
+    })?;
+
+    // Start upload and then abort
+    let cfg = MultipartUploadConfig { part_size: 16 * 1024 * 1024, max_in_flight: 4, ..Default::default() };
+    let mut sink = MultipartUploadSink::new(&bucket, key, cfg)?;
+    sink.write_blocking(&vec![0xCD; 5 * 1024 * 1024])?;
+    sink.flush_blocking()?;     // force a part upload to start
+    sink.abort_blocking()?;     // abort the MPU
+
+    // Object should not exist
+    run_on_global_rt({
+        let bucket = bucket.clone();
+        let key = key.to_string();
+        async move {
+            let client = aws_s3_client_async().await?;
+            let head = client.head_object().bucket(&bucket).key(&key).send().await;
+            ensure!(head.is_err(), "object unexpectedly exists after abort");
+            let _ = client.delete_bucket().bucket(&bucket).send().await;
+            Ok::<(), anyhow::Error>(())
+        }
+    })?;
+
+    Ok(())
+}
+


### PR DESCRIPTION
Added a multi-part uploader.  This includes the ability to do so with zero buffer copies between Python and Rust.  This works by providing a function, that Rust executes and allocates the space for.  Python can then fill the memory region, and give it back to Rust.  This all occurs zero-copy with Rust managing lifetimes.  At this point, the memory region can be streamed to the S3 back-end, including using multi-part upload.