### PR TITLE
Release v0.8.9: Build quality improvements and dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,9 +208,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-config"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c478f5b10ce55c9a33f87ca3404ca92768b144fc1bfdede7c0121214a8283a25"
+checksum = "8bc1b40fb26027769f16960d2f4a6bc20c4bb755d403e552c8c1a73af433c246"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -260,9 +260,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.32.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba2e2516bdf37af57fc6ff047855f54abad0066e5c4fdaaeb76dabb2e05bcf5"
+checksum = "a2b715a6010afb9e457ca2b7c9d2b9c344baa8baed7b38dc476034c171b32575"
 dependencies = [
  "bindgen",
  "cc",
@@ -299,9 +299,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.103.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af040a86ae4378b7ed2f62c83b36be1848709bbbf5757ec850d0e08596a26be9"
+checksum = "2c230530df49ed3f2b7b4d9c8613b72a04cdac6452eede16d587fc62addfabac"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -333,9 +333,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.82.0"
+version = "1.84.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b069e4973dc25875bbd54e4c6658bdb4086a846ee9ed50f328d4d4c33ebf9857"
+checksum = "357a841807f6b52cb26123878b3326921e2a25faca412fabdd32bd35b7edd5d3"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -355,9 +355,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.83.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b49e8fe57ff100a2f717abfa65bdd94e39702fa5ab3f60cddc6ac7784010c68"
+checksum = "9d1cc7fb324aa12eb4404210e6381195c5b5e9d52c2682384f295f38716dd3c7"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.84.0"
+version = "1.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91abcdbfb48c38a0419eb75e0eac772a4783a96750392680e4f3c25a8a0535b9"
+checksum = "e7d835f123f307cafffca7b9027c14979f1d403b417d8541d67cf252e8a21e35"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -492,6 +492,8 @@ dependencies = [
 [[package]]
 name = "aws-smithy-http-client"
 version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147e8eea63a40315d704b97bf9bc9b8c1402ae94f89d5ad6f7550d963309da1b"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -547,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.9.0"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3d57c8b53a72d15c8e190475743acf34e4996685e346a3448dd54ef696fc6e0"
+checksum = "4fa63ad37685ceb7762fa4d73d06f1d5493feb88e3f27259b9ed277f4c01b185"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -805,7 +807,7 @@ dependencies = [
  "bitflags 2.9.4",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1591,7 +1593,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2088,6 +2090,12 @@ dependencies = [
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "hdf5-metno"
@@ -2624,7 +2632,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -2768,6 +2776,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -2829,7 +2846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -4243,7 +4260,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -4362,7 +4379,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.8.7"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4844,7 +4861,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5671,7 +5688,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3dlio"
-version = "0.8.8"
+version = "0.8.9"
 edition = "2024"
 
 [lib]
@@ -132,10 +132,20 @@ enhanced-http = ["dep:reqwest"]      # Enhanced HTTP client with HTTP/2 support
 direct-io = ["dep:nix"]              # O_DIRECT file I/O for high-performance storage
 profiling = ["dep:console-subscriber", "dep:pprof"]  # tracing deps now always available
 extension-module = ["dep:pyo3", "dep:pyo3-async-runtimes"]     # suppresses the cfg warning when building the wheel
+experimental-http-client = []        # Enable custom hyper_builder optimizations (requires patched aws-smithy-http-client)
 
-[patch.crates-io]
-# Use our patched version to expose hyper_builder methods for HTTP connection pool configuration
-aws-smithy-http-client = { path = "fork-patches/aws-smithy-http-client" }
+# NOTE: Custom aws-smithy-http-client patches are DISABLED by default
+# The fork-patches/aws-smithy-http-client/ directory contains experimental HTTP connection
+# pool configuration changes that were tested but showed no measurable performance benefit.
+# Keeping fork available for reference/experimentation but not forcing downstream users
+# to patch their dependencies.
+#
+# To enable experimental HTTP client optimizations (NOT RECOMMENDED):
+# 1. Uncomment the [patch.crates-io] section below
+# 2. Build with: cargo build --features experimental-http-client
+#
+# [patch.crates-io]
+# aws-smithy-http-client = { path = "fork-patches/aws-smithy-http-client" }
 
 [[example]]
 name = "s3_backend_comparison"

--- a/README.md
+++ b/README.md
@@ -39,14 +39,28 @@ s3dlio provides a unified interface for all storage operations, treating upload/
 - **⚡ DirectIO**: `direct:///path/to/directory/` - Bypass OS cache for maximum I/O performance
 
 ### S3 Backend Options
-Choose an optimal S3 backend:
-```bash
-# Apache Arrow backend (recommended for modern deployments)
-cargo build --no-default-features --features arrow-backend
+s3dlio supports two S3 backend implementations. **Native AWS SDK is the default and recommended** for production use:
 
-# Native AWS SDK backend (proven performance)
+```bash
+# Default: Native AWS SDK backend (RECOMMENDED for production)
+cargo build --release
+# or explicitly:
 cargo build --no-default-features --features native-backends
+
+# Experimental: Apache Arrow object_store backend (optional, for testing)
+cargo build --no-default-features --features arrow-backend
 ```
+
+**Why native-backends is default:**
+- Proven performance in production workloads
+- Optimized for high-throughput S3 operations (5+ GB/s reads, 2.5+ GB/s writes)
+- Well-tested with MinIO, Vast, and AWS S3
+
+**About arrow-backend:**
+- Experimental alternative implementation
+- No proven performance advantage over native backend
+- Useful for comparison testing and development
+- Not recommended for production use
 
 ## Quick Start
 

--- a/docs/performance/Apache_Arrow_Backend_Implementation.md
+++ b/docs/performance/Apache_Arrow_Backend_Implementation.md
@@ -2,11 +2,14 @@
 
 **Version**: 0.7.10  
 **Date**: September 19, 2025  
-**Status**: Completed ✅
+**Status**: Experimental - Not Production Ready
+
+**⚠️ IMPORTANT UPDATE (October 2025):**  
+Subsequent production testing has shown that the Arrow backend does NOT provide consistent performance benefits over the native AWS SDK backend. Initial benchmarks were promising but did not reflect real-world production workload performance. The arrow-backend feature is retained for comparison testing and development purposes only. **native-backends remains the default and recommended configuration for production use.**
 
 ## Overview
 
-This document describes the implementation of an Apache Arrow `object_store` backend as an alternative to the native AWS SDK for s3dlio. The Arrow backend provides comparable performance while offering better ecosystem compatibility and potential future benefits.
+This document describes the implementation of an Apache Arrow `object_store` backend as an alternative to the native AWS SDK for s3dlio. Initial testing suggested comparable performance, but production validation showed the native backend performs better for sustained high-throughput workloads.
 
 ## Implementation Summary
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.8.8"
+version = "0.8.9"
 description = "Multi-protocol AI/ML storage library with zero-copy streaming, checkpointing, and data loading capabilities"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -23,7 +23,7 @@ use std::str::FromStr; // For the custom S3Path type
 use std::time::Instant;
 use std::sync::Arc;
 use tracing::{info, warn};
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::EnvFilter;
 use tempfile::NamedTempFile;
 use glob;
 

--- a/src/object_store_arrow.rs
+++ b/src/object_store_arrow.rs
@@ -3,7 +3,10 @@
 // Arrow-backed adapter for s3dlio's ObjectStore trait.
 // Routes I/O through the Apache Arrow `object_store` crate.
 //
-// Build: gated behind feature "arrow-backend" (recommended).
+// Build: gated behind feature "arrow-backend" (EXPERIMENTAL - NOT production ready).
+//
+// NOTE: This backend is experimental and has NOT shown performance benefits over
+// native-backends in production testing. Kept for comparison testing only.
 //
 // This module is intentionally "stateless": each call parses the full URI and
 // constructs (or reuses) the appropriate backend via object_store::parse_url.

--- a/src/python_api/python_aiml_api.rs
+++ b/src/python_api/python_aiml_api.rs
@@ -569,6 +569,7 @@ fn opts_from_dict(d: Option<Bound<'_, PyDict>>) -> LoaderOptions {
             generator_seed:       def.generator_seed,
             enable_transforms:    def.enable_transforms,
             collate_buffer_size:  def.collate_buffer_size,
+            page_cache_mode:      def.page_cache_mode,  // Use default (Auto)
         }
     } else {
         def

--- a/src/python_api/python_core_api.rs
+++ b/src/python_api/python_core_api.rs
@@ -16,7 +16,7 @@ use tokio::task;
 
 use std::path::PathBuf;
 
-use tracing::Level;
+use tracing::{Level, warn};
 use tracing_subscriber;
 
 // Project crates


### PR DESCRIPTION
- Fixed unused import warning in cli.rs (zero warnings policy enforced)
- Removed forced aws-smithy-http-client patch from Cargo.toml
- Added experimental-http-client feature flag for optional HTTP optimizations
- Updated all documentation to clarify native-backends is default and recommended
- Corrected arrow-backend documentation (experimental, no proven benefit)
- Updated AWS SDK dependencies (aws-sdk-s3 1.103.0 -> 1.106.0)
- Added comprehensive build quality standards to copilot-instructions
- Fixed Python API to include page_cache_mode with sensible default
- Enhanced UV virtual environment usage documentation

All changes maintain backward compatibility. Default build uses standard AWS SDK with zero warnings. Experimental HTTP client requires manual opt-in.