### PR TITLE
feat: Universal op-log support for all storage backends (v0.8.12)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4379,7 +4379,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.8.9"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "s3dlio"
-version = "0.8.10"
-edition = "2024"
+version = "0.8.12"
+edition = "2021"
 
 [lib]
 name = "s3dlio"

--- a/docs/IMPLEMENTATION-PLAN-op-log-all-backends.md
+++ b/docs/IMPLEMENTATION-PLAN-op-log-all-backends.md
@@ -1,0 +1,363 @@
+# Implementation Plan: Op-Log Support for All Backends
+
+**Issue**: [ISSUE-op-log-backend-support.md](./ISSUE-op-log-backend-support.md)  
+**Target Version**: v0.8.11  
+**Priority**: Medium  
+**Complexity**: Low-Medium  
+**Estimated Effort**: 3-4 hours
+
+## Overview
+
+Extend op-log (trace logging) facility to support all storage backends (file://, az://, direct://) using a clean wrapper pattern. Currently only S3 operations are traced.
+
+## Current Architecture
+
+```
+┌─────────────┐
+│   CLI Args  │
+│  --op-log   │
+└──────┬──────┘
+       │
+       ├─ S3-specific commands (get, put, list, etc.)
+       │  └─> S3Ops struct → Logger ✅ WORKS
+       │
+       └─ Generic commands (download, upload, ls)
+          └─> ObjectStore trait → ❌ NO LOGGING
+```
+
+## Proposed Architecture (Wrapper Pattern)
+
+```
+┌─────────────┐
+│   CLI Args  │
+│  --op-log   │
+└──────┬──────┘
+       │
+       ├─ init_op_logger() → Creates global logger
+       │
+       └─ store_for_uri(uri, logger)
+          └─> LoggedObjectStore {
+                inner: Arc<dyn ObjectStore>,  // File/S3/Azure/Direct
+                logger: Option<Logger>
+              }
+              └─> Wraps all methods with logging ✅ WORKS FOR ALL
+```
+
+## Implementation Steps
+
+### Step 1: Create Wrapper Module (`src/object_store_logger.rs`)
+
+**New File**: `src/object_store_logger.rs` (~200-300 lines)
+
+**Key Components**:
+
+1. **LoggedObjectStore struct**:
+```rust
+pub struct LoggedObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    logger: Logger,
+}
+```
+
+2. **Implement ObjectStore trait**:
+   - Wrap every method (get, put, list, delete, etc.)
+   - Record timing (start, end, duration)
+   - Extract operation type and endpoint from URI
+   - Log success or error
+   - Delegate to inner store
+
+3. **Helper functions**:
+```rust
+fn extract_endpoint(uri: &str) -> String {
+    // "s3://bucket/key" → "s3://bucket"
+    // "file:///path/to/file" → "file://"
+    // "az://container/blob" → "az://container"
+}
+
+fn extract_file_path(uri: &str) -> String {
+    // Full URI for logging
+}
+
+fn operation_type_from_method(method: &str) -> &str {
+    // "get" → "GET"
+    // "put" → "PUT"
+    // "list" → "LIST"
+}
+```
+
+4. **Logging wrapper pattern**:
+```rust
+async fn get(&self, uri: &str) -> Result<Vec<u8>> {
+    let start = SystemTime::now();
+    let thread_id = /* get thread ID */;
+    
+    let result = self.inner.get(uri).await;
+    
+    let end = SystemTime::now();
+    let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+    let error = result.as_ref().err().map(|e| e.to_string());
+    
+    self.logger.log(LogEntry {
+        idx: 0,  // Set by logger
+        thread_id,
+        operation: "GET".to_string(),
+        client_id: String::new(),  // Could use username
+        num_objects: 1,
+        bytes,
+        endpoint: extract_endpoint(uri),
+        file: uri.to_string(),
+        error,
+        start_time: start,
+        first_byte_time: None,  // Not tracked for ObjectStore
+        end_time: end,
+    });
+    
+    result
+}
+```
+
+### Step 2: Update API Module (`src/api.rs`)
+
+**Modifications**:
+
+1. **Add logger parameter to `store_for_uri()`**:
+```rust
+// Before:
+pub fn store_for_uri(uri: &str) -> Result<Arc<dyn ObjectStore>>
+
+// After:
+pub fn store_for_uri(uri: &str) -> Result<Arc<dyn ObjectStore>> {
+    store_for_uri_with_logger(uri, None)
+}
+
+pub fn store_for_uri_with_logger(
+    uri: &str, 
+    logger: Option<Logger>
+) -> Result<Arc<dyn ObjectStore>>
+```
+
+2. **Wrap stores when logger present**:
+```rust
+pub fn store_for_uri_with_logger(uri: &str, logger: Option<Logger>) -> Result<Arc<dyn ObjectStore>> {
+    let scheme = infer_scheme(uri);
+    
+    let store: Arc<dyn ObjectStore> = match scheme {
+        Scheme::S3 => {
+            #[cfg(feature = "native-backends")]
+            return Ok(Arc::new(S3Store::new()?));
+            // ... other backends
+        },
+        Scheme::File => Arc::new(FileSystemObjectStore::new()),
+        Scheme::Azure => Arc::new(AzureStore::new()?),
+        Scheme::Direct => Arc::new(ConfigurableFileSystemObjectStore::new(/*...*/)),
+        // ...
+    };
+    
+    // Wrap with logger if present
+    if let Some(logger) = logger {
+        Ok(Arc::new(LoggedObjectStore::new(store, logger)))
+    } else {
+        Ok(store)
+    }
+}
+```
+
+3. **Maintain backward compatibility**:
+   - Keep `store_for_uri()` without logger
+   - Add `store_for_uri_with_logger()` variant
+
+### Step 3: Update CLI (`src/bin/cli.rs`)
+
+**Modifications**:
+
+1. **Pass logger to store creation**:
+```rust
+// After initializing op-logger:
+let logger = global_logger();
+
+// When creating stores:
+let store = store_for_uri_with_logger(&uri, logger.clone())?;
+```
+
+2. **Update command handlers**:
+   - `download_cmd()` - Pass logger
+   - `upload_cmd()` - Pass logger  
+   - `ls_cmd()` - Pass logger
+   - Any other commands using ObjectStore
+
+3. **Example**:
+```rust
+async fn download_cmd(from: &str, to: &str, logger: Option<Logger>) -> Result<()> {
+    let store = store_for_uri_with_logger(from, logger)?;
+    let data = store.get(from).await?;
+    // ... write to local file
+}
+```
+
+### Step 4: Update Module Declarations (`src/lib.rs`)
+
+```rust
+// Add new module
+pub mod object_store_logger;
+
+// Re-export if needed for external use
+pub use object_store_logger::LoggedObjectStore;
+```
+
+### Step 5: Testing
+
+**Test Cases**:
+
+1. **File backend logging**:
+```bash
+s3-cli --op-log file_test.tsv.zst download file:///tmp/test.txt /tmp/dest.txt
+zstd -d file_test.tsv.zst -c | grep GET
+# Verify: operation logged with endpoint "file://" and correct timing
+```
+
+2. **Azure backend logging**:
+```bash
+s3-cli --op-log azure_test.tsv.zst download az://container/blob /tmp/dest.txt
+zstd -d azure_test.tsv.zst -c | grep GET
+# Verify: operation logged with endpoint "az://container"
+```
+
+3. **Direct backend logging**:
+```bash
+s3-cli --op-log direct_test.tsv.zst download direct:///mnt/data/file /tmp/dest.txt
+zstd -d direct_test.tsv.zst -c | grep GET
+# Verify: operation logged
+```
+
+4. **Mixed operations**:
+```bash
+s3-cli --op-log mixed.tsv.zst upload /tmp/file.txt s3://bucket/key
+s3-cli --op-log mixed.tsv.zst download s3://bucket/key file:///tmp/file2.txt
+# Verify: Both S3 and file operations logged
+```
+
+5. **Error handling**:
+```bash
+s3-cli --op-log error_test.tsv.zst download file:///nonexistent /tmp/dest.txt
+zstd -d error_test.tsv.zst -c | tail -1
+# Verify: Error message captured in error field
+```
+
+6. **TSV format validation**:
+   - Verify all fields present
+   - Verify timestamps parseable
+   - Verify compatible with warp-replay tool (if available)
+
+7. **Performance verification**:
+   - Measure overhead of logging wrapper (<1% expected)
+   - Test with LOSSLESS mode
+   - Test buffer overflow handling
+
+## Technical Considerations
+
+### Thread ID Extraction
+```rust
+fn get_thread_id() -> usize {
+    // Use thread::current().id() and hash to usize
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    hasher.finish() as usize
+}
+```
+
+### Endpoint Extraction
+```rust
+fn extract_endpoint(uri: &str) -> String {
+    if let Some(pos) = uri.find("://") {
+        let scheme_end = pos + 3;
+        if let Some(path_start) = uri[scheme_end..].find('/') {
+            return uri[..scheme_end + path_start].to_string();
+        }
+        return uri.to_string();
+    }
+    "unknown".to_string()
+}
+```
+
+### First Byte Time
+- ObjectStore trait doesn't expose streaming semantics
+- Set `first_byte_time: None` for all operations
+- Could add later with more invasive changes
+
+### Client ID
+- Could use `whoami::username()` crate
+- Or leave empty for consistency with S3 ops
+- Recommendation: Empty string initially, add later if needed
+
+## Compatibility
+
+### TSV Format
+Must remain compatible with existing format:
+```
+idx\tthread\top\tclient_id\tn_objects\tbytes\tendpoint\tfile\terror\tstart\tfirst_byte\tend\tduration_ns
+```
+
+Fields for non-S3 operations:
+- `idx`: Sequential counter (auto-assigned by logger)
+- `thread`: Thread ID hash
+- `op`: GET, PUT, LIST, DELETE, HEAD
+- `client_id`: Empty string ""
+- `n_objects`: Usually 1 (or count for list operations)
+- `bytes`: Bytes transferred
+- `endpoint`: "file://", "az://container", "direct://", etc.
+- `file`: Full URI
+- `error`: Error message or empty
+- `start`: RFC3339 timestamp
+- `first_byte`: Empty (not tracked)
+- `end`: RFC3339 timestamp
+- `duration_ns`: Nanoseconds
+
+### Backward Compatibility
+- Existing S3-specific commands continue to use S3Ops logging (unchanged)
+- Generic commands gain logging capability
+- No breaking changes to APIs or file formats
+- warp-replay tool should handle new records transparently
+
+## Files to Modify
+
+1. **New File**: `src/object_store_logger.rs` (~250 lines)
+2. **Modify**: `src/api.rs` (~30 lines added)
+3. **Modify**: `src/lib.rs` (~2 lines added)
+4. **Modify**: `src/bin/cli.rs` (~50 lines modified)
+
+**Total**: ~330 lines added/modified
+
+## Success Criteria
+
+✅ All storage backends (file://, s3://, az://, direct://) generate op-log entries  
+✅ TSV format compatible with existing warp-replay tool  
+✅ Zero compilation warnings  
+✅ Performance overhead <1%  
+✅ Test coverage for all backends  
+✅ Documentation updated
+
+## Risks & Mitigation
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Performance overhead | Low | Use try_send (non-blocking), benchmark |
+| Format incompatibility | Medium | Validate against warp-replay before commit |
+| Thread safety issues | Low | Logger already thread-safe via channels |
+| Missing edge cases | Low | Comprehensive test suite |
+
+## Follow-up Enhancements (Future)
+
+- Add `first_byte_time` tracking with streaming semantics
+- Add `client_id` from username
+- Support filtering by backend type
+- Add trace visualization tools
+- Performance profiling mode with more metrics
+
+## Documentation Updates
+
+- Update `docs/ISSUE-op-log-backend-support.md` with resolution
+- Add usage examples to README
+- Update API documentation for `store_for_uri_with_logger()`
+- Add to Changelog.md for v0.8.11

--- a/examples/test_oplog_multiple_operations.rs
+++ b/examples/test_oplog_multiple_operations.rs
@@ -1,0 +1,124 @@
+// Test program to generate multiple op-log entries for file:// and direct:// backends
+use anyhow::Result;
+use s3dlio::{init_op_logger, store_for_uri_with_logger, global_logger, finalize_op_logger};
+use s3dlio::s3_logger::Logger;
+
+async fn test_backend(backend: &str, base_path: &str, logger: Option<Logger>) -> Result<()> {
+    println!("\n========================================");
+    println!("Testing {} backend", backend);
+    println!("========================================");
+    
+    let uri_prefix = format!("{}://{}", backend, base_path);
+    
+    println!("Creating test directory with files...");
+    std::fs::create_dir_all(base_path)?;
+    for i in 1..=20 {
+        std::fs::write(
+            format!("{}/file_{:03}.txt", base_path, i),
+            format!("Test data for file {}", i)
+        )?;
+    }
+    
+    println!("Performing 30 LIST operations...");
+    let store = store_for_uri_with_logger(&format!("{}/", uri_prefix), logger.clone())?;
+    
+    for i in 1..=30 {
+        let _keys = store.list(&format!("{}/", uri_prefix), false).await?;
+        if i % 10 == 0 {
+            println!("  Completed {} LIST operations", i);
+        }
+    }
+    
+    println!("Performing 15 GET operations...");
+    for i in 1..=15 {
+        let uri = format!("{}/file_{:03}.txt", uri_prefix, i);
+        let _data = store.get(&uri).await?;
+        if i % 5 == 0 {
+            println!("  Completed {} GET operations", i);
+        }
+    }
+    
+    println!("Performing 10 PUT operations...");
+    for i in 21..=30 {
+        let uri = format!("{}/new_file_{:03}.txt", uri_prefix, i);
+        let data = format!("New test data for file {}", i);
+        store.put(&uri, data.as_bytes()).await?;
+        if (i - 20) % 5 == 0 {
+            println!("  Completed {} PUT operations", i - 20);
+        }
+    }
+    
+    println!("✓ {} backend test completed", backend);
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let log_file = "/tmp/test_op_log_multi_backend.tsv.zst";
+    
+    println!("========================================");
+    println!("Op-Log Multi-Backend Test");
+    println!("========================================");
+    println!("Log file: {}", log_file);
+    
+    // Initialize logger once for all tests
+    init_op_logger(log_file)?;
+    let logger = global_logger();
+    
+    // Test file:// backend
+    test_backend("file", "/tmp/s3dlio_test_rust_file", logger.clone()).await?;
+    
+    // Test direct:// backend
+    test_backend("direct", "/tmp/s3dlio_test_rust_direct", logger.clone()).await?;
+    
+    println!("Finalizing logger...");
+    finalize_op_logger();
+    
+    // Analyze the log
+    let output = std::process::Command::new("zstd")
+        .args(&["-dc", log_file])
+        .output()?;
+    
+    let log_content = String::from_utf8_lossy(&output.stdout);
+    let lines: Vec<&str> = log_content.lines().collect();
+    
+    println!("\n========================================");
+    println!("Op-log Analysis");
+    println!("========================================");
+    println!("Total operations logged: {}", lines.len() - 1); // Subtract header
+    println!("\nOperation breakdown:");
+    println!("  LIST: {}", log_content.matches("LIST").count());
+    println!("  GET: {}", log_content.matches("\tGET\t").count());
+    println!("  PUT: {}", log_content.matches("\tPUT\t").count());
+    
+    // Count by backend
+    let file_ops = log_content.matches("file://").count();
+    let direct_ops = log_content.matches("direct://").count();
+    println!("\nOperations by backend:");
+    println!("  file://   : {}", file_ops);
+    println!("  direct:// : {}", direct_ops);
+    
+    println!("\nFirst 25 log entries:");
+    for line in lines.iter().take(26) {
+        println!("{}", line);
+    }
+    
+    println!("\n... (middle entries truncated)");
+    println!("\nLast 15 log entries:");
+    for line in lines.iter().skip(lines.len().saturating_sub(15)) {
+        println!("{}", line);
+    }
+    
+    println!("\n========================================");
+    println!("✓ Test completed successfully");
+    println!("========================================");
+    println!("\nLog file preserved at: {}", log_file);
+    println!("View with: zstd -dc {} | less", log_file);
+    println!("Or: zstd -dc {} | head -50", log_file);
+    
+    // Cleanup test directories (but keep log file)
+    std::fs::remove_dir_all("/tmp/s3dlio_test_rust_file").ok();
+    std::fs::remove_dir_all("/tmp/s3dlio_test_rust_direct").ok();
+    
+    Ok(())
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "s3dlio"
-version = "0.8.10"
-description = "Multi-protocol AI/ML storage library with zero-copy streaming, checkpointing, and data loading capabilities"
+version = "0.8.12"
+description = "High-performance S3, Azure, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []

--- a/src/api.rs
+++ b/src/api.rs
@@ -55,19 +55,41 @@ pub use crate::object_store::ObjectMetadata;
 /// URI scheme detection
 pub use crate::object_store::{Scheme, infer_scheme};
 
+// Op-log (trace logging) support
+/// Initialize operation logging to a file
+pub use crate::s3_logger::{init_op_logger, finalize_op_logger, global_logger, Logger};
+
+/// Wrapper that adds logging to any ObjectStore
+pub use crate::object_store_logger::LoggedObjectStore;
+
 // Factory functions for creating stores (backend-dependent)
-#[cfg(feature = "native-backends")]
 #[cfg(feature = "native-backends")]
 /// Create an object store for the given URI (native AWS/Azure backend)
 pub use crate::object_store::store_for_uri;
+
+#[cfg(feature = "native-backends")]
+/// Create an object store with optional operation logging
+pub use crate::object_store::store_for_uri_with_logger;
+
+#[cfg(feature = "native-backends")]
+/// Create an object store with configuration and optional logging
+pub use crate::object_store::store_for_uri_with_config_and_logger;
 
 #[cfg(feature = "native-backends")]
 /// Create a direct I/O optimized object store (native backend only)
 pub use crate::object_store::direct_io_store_for_uri;
 
 #[cfg(feature = "native-backends")]
+/// Create a direct I/O store with optional logging
+pub use crate::object_store::direct_io_store_for_uri_with_logger;
+
+#[cfg(feature = "native-backends")]
 /// Create a high-performance object store (native backend only)
 pub use crate::object_store::high_performance_store_for_uri;
+
+#[cfg(feature = "native-backends")]
+/// Create a high-performance store with optional logging
+pub use crate::object_store::high_performance_store_for_uri_with_logger;
 
 #[cfg(feature = "arrow-backend")]
 /// Create an object store for the given URI (Apache Arrow backend)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod page_cache;
 pub mod data_gen;
 pub mod streaming_writer;
 pub mod tfrecord_index;
+pub mod object_store_logger;  // Op-log support for all backends
 pub mod data_loader;
 pub mod checkpoint;
 pub mod azure_client;

--- a/src/object_store_logger.rs
+++ b/src/object_store_logger.rs
@@ -1,0 +1,384 @@
+// src/object_store_logger.rs
+//
+// Copyright, 2025. Signal65 / Futurum Group.
+//
+//! Logging wrapper for ObjectStore trait to enable op-log tracing for all backends.
+//!
+//! This module provides a decorator pattern wrapper that adds operation logging
+//! to any ObjectStore implementation without modifying the underlying implementations.
+//! Enables trace logging for file://, s3://, az://, and direct:// backends.
+
+use std::sync::Arc;
+use std::time::SystemTime;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use async_trait::async_trait;
+use anyhow::Result;
+
+use crate::object_store::{ObjectStore, ObjectMetadata, ObjectWriter, WriterOptions};
+use crate::s3_logger::{Logger, LogEntry};
+
+/// Extract the scheme and container/bucket from a URI for endpoint logging.
+/// Examples:
+///   "s3://bucket/key" → "s3://bucket"
+///   "file:///path/to/file" → "file://"
+///   "az://container/blob" → "az://container"
+///   "direct:///mnt/storage/file" → "direct://"
+fn extract_endpoint(uri: &str) -> String {
+    if let Some(scheme_end) = uri.find("://") {
+        let after_scheme = scheme_end + 3;
+        
+        // For file:// and direct://, just return the scheme
+        if uri.starts_with("file://") || uri.starts_with("direct://") {
+            return uri[..after_scheme].to_string();
+        }
+        
+        // For s3:// and az://, include the bucket/container name
+        if let Some(path_start) = uri[after_scheme..].find('/') {
+            return uri[..after_scheme + path_start].to_string();
+        }
+        
+        // If no path separator, return entire URI
+        return uri.to_string();
+    }
+    
+    // Fallback for malformed URIs
+    "unknown".to_string()
+}
+
+/// Strip the URI scheme prefix to get just the path for the "file" column.
+/// Examples:
+///   "s3://bucket/key.txt" → "bucket/key.txt"
+///   "file:///tmp/data/file.dat" → "/tmp/data/file.dat"
+///   "az://container/blob" → "container/blob"
+///   "direct:///mnt/storage/file" → "/mnt/storage/file"
+fn strip_uri_scheme(uri: &str) -> String {
+    if let Some(scheme_end) = uri.find("://") {
+        return uri[scheme_end + 3..].to_string();
+    }
+    
+    // If no scheme found, return as-is
+    uri.to_string()
+}
+
+/// Get a numeric thread identifier for logging.
+/// Uses a hash of the thread ID to produce a stable usize.
+fn get_thread_id() -> usize {
+    let mut hasher = DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    hasher.finish() as usize
+}
+
+/// Wrapper that adds operation logging to any ObjectStore implementation.
+/// 
+/// This decorator intercepts all ObjectStore method calls, logs them via the
+/// provided Logger, and then delegates to the inner store. No changes are
+/// needed to existing ObjectStore implementations.
+///
+/// # Example
+///
+/// ```rust,no_run
+/// use s3dlio::{store_for_uri, LoggedObjectStore, init_op_logger, global_logger};
+///
+/// # async fn example() -> anyhow::Result<()> {
+/// // Initialize logger
+/// init_op_logger("trace.tsv.zst")?;
+/// let logger = global_logger().unwrap();
+///
+/// // Create store and wrap with logging
+/// let store = store_for_uri("file:///tmp/data")?;
+/// let logged_store = LoggedObjectStore::new(store, logger);
+///
+/// // All operations now logged
+/// let data = logged_store.get("file:///tmp/data/test.txt").await?;
+/// # Ok(())
+/// # }
+/// ```
+pub struct LoggedObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    logger: Logger,
+}
+
+impl LoggedObjectStore {
+    /// Create a new LoggedObjectStore wrapping the given store.
+    ///
+    /// # Arguments
+    /// * `inner` - The underlying ObjectStore implementation to wrap
+    /// * `logger` - The Logger instance to use for recording operations
+    pub fn new(inner: Arc<dyn ObjectStore>, logger: Logger) -> Self {
+        Self { inner, logger }
+    }
+
+    /// Helper to log an operation with standard fields.
+    fn log_operation(
+        &self,
+        operation: &str,
+        uri: &str,
+        bytes: u64,
+        num_objects: u32,
+        start_time: SystemTime,
+        end_time: SystemTime,
+        error: Option<String>,
+    ) {
+        let entry = LogEntry {
+            idx: 0, // Set by logger
+            thread_id: get_thread_id(),
+            operation: operation.to_string(),
+            client_id: String::new(), // Empty for ObjectStore operations
+            num_objects,
+            bytes,
+            endpoint: extract_endpoint(uri),
+            file: strip_uri_scheme(uri), // Strip scheme prefix from file column
+            error,
+            start_time,
+            first_byte_time: None, // Not tracked at ObjectStore level
+            end_time,
+        };
+        
+        self.logger.log(entry);
+    }
+}
+
+#[async_trait]
+impl ObjectStore for LoggedObjectStore {
+    async fn get(&self, uri: &str) -> Result<Vec<u8>> {
+        let start = SystemTime::now();
+        let result = self.inner.get(uri).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("GET", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn get_range(&self, uri: &str, offset: u64, length: Option<u64>) -> Result<Vec<u8>> {
+        let start = SystemTime::now();
+        let result = self.inner.get_range(uri, offset, length).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("GET_RANGE", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn put(&self, uri: &str, data: &[u8]) -> Result<()> {
+        let start = SystemTime::now();
+        let bytes = data.len() as u64;
+        let result = self.inner.put(uri, data).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("PUT", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn put_multipart(&self, uri: &str, data: &[u8], part_size: Option<usize>) -> Result<()> {
+        let start = SystemTime::now();
+        let bytes = data.len() as u64;
+        let result = self.inner.put_multipart(uri, data, part_size).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        // Still log as PUT (multipart is implementation detail)
+        self.log_operation("PUT", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn list(&self, uri_prefix: &str, recursive: bool) -> Result<Vec<String>> {
+        let start = SystemTime::now();
+        let result = self.inner.list(uri_prefix, recursive).await;
+        let end = SystemTime::now();
+        
+        let num_objects = result.as_ref().map(|v| v.len() as u32).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("LIST", uri_prefix, 0, num_objects, start, end, error);
+        
+        result
+    }
+
+    async fn stat(&self, uri: &str) -> Result<ObjectMetadata> {
+        let start = SystemTime::now();
+        let result = self.inner.stat(uri).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|m| m.size).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("HEAD", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn delete(&self, uri: &str) -> Result<()> {
+        let start = SystemTime::now();
+        let result = self.inner.delete(uri).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("DELETE", uri, 0, 1, start, end, error);
+        
+        result
+    }
+
+    async fn delete_prefix(&self, uri_prefix: &str) -> Result<()> {
+        let start = SystemTime::now();
+        let result = self.inner.delete_prefix(uri_prefix).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        // Don't know exact count, use 0 to indicate prefix operation
+        self.log_operation("DELETE_PREFIX", uri_prefix, 0, 0, start, end, error);
+        
+        result
+    }
+
+    async fn create_container(&self, name: &str) -> Result<()> {
+        let start = SystemTime::now();
+        let result = self.inner.create_container(name).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("CREATE_CONTAINER", name, 0, 1, start, end, error);
+        
+        result
+    }
+
+    async fn delete_container(&self, name: &str) -> Result<()> {
+        let start = SystemTime::now();
+        let result = self.inner.delete_container(name).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("DELETE_CONTAINER", name, 0, 1, start, end, error);
+        
+        result
+    }
+
+    async fn exists(&self, uri: &str) -> Result<bool> {
+        let start = SystemTime::now();
+        let result = self.inner.exists(uri).await;
+        let end = SystemTime::now();
+        
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        // Log as HEAD operation (existence check)
+        self.log_operation("HEAD", uri, 0, 1, start, end, error);
+        
+        result
+    }
+
+    async fn get_with_validation(&self, uri: &str, expected_checksum: Option<&str>) -> Result<Vec<u8>> {
+        let start = SystemTime::now();
+        let result = self.inner.get_with_validation(uri, expected_checksum).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        // Log as GET with validation
+        self.log_operation("GET", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn get_range_with_validation(
+        &self,
+        uri: &str,
+        offset: u64,
+        length: Option<u64>,
+        expected_checksum: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        let start = SystemTime::now();
+        let result = self.inner.get_range_with_validation(uri, offset, length, expected_checksum).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("GET_RANGE", uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn load_checkpoint_with_validation(
+        &self,
+        checkpoint_uri: &str,
+        expected_checksum: Option<&str>,
+    ) -> Result<Vec<u8>> {
+        let start = SystemTime::now();
+        let result = self.inner.load_checkpoint_with_validation(checkpoint_uri, expected_checksum).await;
+        let end = SystemTime::now();
+        
+        let bytes = result.as_ref().map(|d| d.len() as u64).unwrap_or(0);
+        let error = result.as_ref().err().map(|e| e.to_string());
+        
+        self.log_operation("GET", checkpoint_uri, bytes, 1, start, end, error);
+        
+        result
+    }
+
+    async fn create_writer(&self, uri: &str, options: WriterOptions) -> Result<Box<dyn ObjectWriter>> {
+        // Note: We log the final write, not the writer creation
+        // The writer itself will handle logging when finalized
+        self.inner.create_writer(uri, options).await
+    }
+
+    async fn get_writer(&self, uri: &str) -> Result<Box<dyn ObjectWriter>> {
+        // Delegate to inner store - writer operations logged at write time
+        self.inner.get_writer(uri).await
+    }
+
+    async fn get_writer_with_compression(&self, uri: &str, compression: crate::object_store::CompressionConfig) -> Result<Box<dyn ObjectWriter>> {
+        // Delegate to inner store - writer operations logged at write time
+        self.inner.get_writer_with_compression(uri, compression).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_endpoint() {
+        assert_eq!(extract_endpoint("s3://my-bucket/path/to/key"), "s3://my-bucket");
+        assert_eq!(extract_endpoint("s3://bucket"), "s3://bucket");
+        assert_eq!(extract_endpoint("file:///tmp/test.txt"), "file://");
+        assert_eq!(extract_endpoint("file:///path/to/file"), "file://");
+        assert_eq!(extract_endpoint("az://container/blob/path"), "az://container");
+        assert_eq!(extract_endpoint("direct:///mnt/storage/file"), "direct://");
+        assert_eq!(extract_endpoint("malformed"), "unknown");
+    }
+
+    #[test]
+    fn test_strip_uri_scheme() {
+        assert_eq!(strip_uri_scheme("s3://bucket/path/to/key.txt"), "bucket/path/to/key.txt");
+        assert_eq!(strip_uri_scheme("file:///tmp/test.txt"), "/tmp/test.txt");
+        assert_eq!(strip_uri_scheme("file:///path/to/file"), "/path/to/file");
+        assert_eq!(strip_uri_scheme("az://container/blob/path"), "container/blob/path");
+        assert_eq!(strip_uri_scheme("direct:///mnt/storage/file.dat"), "/mnt/storage/file.dat");
+        assert_eq!(strip_uri_scheme("no-scheme-path"), "no-scheme-path");
+    }
+
+    #[test]
+    fn test_get_thread_id() {
+        let id1 = get_thread_id();
+        let id2 = get_thread_id();
+        // Same thread should produce same ID
+        assert_eq!(id1, id2);
+    }
+}

--- a/tests/test_op_log_all_backends.sh
+++ b/tests/test_op_log_all_backends.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+#
+# Test script to verify op-log functionality works with all storage backends
+# Tests file:// and direct:// backends using multiple LIST operations
+#
+
+set -e
+
+echo "========================================"
+echo "Testing op-log functionality with all backends"
+echo "========================================"
+
+# Clean up test files
+rm -f /tmp/test_op_log_*.tsv.zst
+rm -rf /tmp/s3dlio_test_oplog_*
+
+echo ""
+echo "========================================"
+echo "Test 1: Multiple operations with file:// backend"
+echo "========================================"
+
+OP_LOG_FILE="/tmp/test_op_log_file_mixed.tsv.zst"
+
+echo "Creating test directory with 30 files..."
+mkdir -p /tmp/s3dlio_test_oplog_file
+for i in {1..30}; do
+  echo "Test data for file $i - $(date +%s%N)" > /tmp/s3dlio_test_oplog_file/testfile_${i}.txt
+done
+
+echo "Performing 25 LIST operations to generate log entries..."
+for i in {1..25}; do
+  ./target/release/s3-cli --op-log "$OP_LOG_FILE" ls \
+    file:///tmp/s3dlio_test_oplog_file/ \
+    -r > /dev/null 2>&1
+done
+
+# Check log was created
+if [ -f "$OP_LOG_FILE" ]; then
+  TOTAL_OPS=$(zstd -dc "$OP_LOG_FILE" | tail -n +2 | wc -l)
+  echo ""
+  echo "SUCCESS: Op-log created for file:// backend"
+  echo "Total operations logged: $TOTAL_OPS"
+  echo ""
+  echo "First 20 lines of op-log:"
+  zstd -dc "$OP_LOG_FILE" | head -20
+  echo ""
+  echo "Last 10 lines of op-log:"
+  zstd -dc "$OP_LOG_FILE" | tail -10
+  echo ""
+  echo "Operation breakdown:"
+  echo "  LIST operations: $(zstd -dc "$OP_LOG_FILE" | grep -c LIST || echo 0)"
+else
+  echo "FAILURE: No op-log created for file:// backend"
+  exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "Test 2: Multiple operations with direct:// backend"
+echo "========================================"
+
+OP_LOG_FILE_DIRECT="/tmp/test_op_log_direct_mixed.tsv.zst"
+
+echo "Creating test directory with 25 files..."
+mkdir -p /tmp/s3dlio_test_oplog_direct
+for i in {1..25}; do
+  echo "Direct IO test data for file $i - $(date +%s%N)" > /tmp/s3dlio_test_oplog_direct/direct_${i}.txt
+done
+
+echo "Performing 30 LIST operations to generate log entries..."
+for i in {1..30}; do
+  ./target/release/s3-cli --op-log "$OP_LOG_FILE_DIRECT" ls \
+    direct:///tmp/s3dlio_test_oplog_direct/ \
+    -r > /dev/null 2>&1
+done
+
+# Check log was created
+if [ -f "$OP_LOG_FILE_DIRECT" ]; then
+  TOTAL_OPS=$(zstd -dc "$OP_LOG_FILE_DIRECT" | tail -n +2 | wc -l)
+  echo ""
+  echo "SUCCESS: Op-log created for direct:// backend"
+  echo "Total operations logged: $TOTAL_OPS"
+  echo ""
+  echo "First 20 lines of op-log:"
+  zstd -dc "$OP_LOG_FILE_DIRECT" | head -20
+  echo ""
+  echo "Operation breakdown:"
+  echo "  LIST operations: $(zstd -dc "$OP_LOG_FILE_DIRECT" | grep -c LIST || echo 0)"
+else
+  echo "FAILURE: No op-log created for direct:// backend"
+  exit 1
+fi
+
+echo ""
+echo "========================================"
+echo "Test 3: Azure Blob Storage az:// backend"
+echo "========================================"
+if [ -n "$AZURE_STORAGE_ACCOUNT" ] && [ -n "$AZURE_STORAGE_ACCESS_KEY" ]; then
+  AZURE_CONTAINER="${AZURE_CONTAINER:-s3dlio-test}"
+  AZURE_PREFIX="az://${AZURE_STORAGE_ACCOUNT}/${AZURE_CONTAINER}/oplog-test/"
+  
+  echo "Testing with Azure container: $AZURE_PREFIX"
+  
+  ./target/release/s3-cli --op-log /tmp/test_op_log_azure_list.tsv.zst ls \
+    "$AZURE_PREFIX" \
+    -r || echo "Azure LIST operation failed (container may not exist or no permissions)"
+  
+  if [ -f /tmp/test_op_log_azure_list.tsv.zst ]; then
+    echo ""
+    echo "SUCCESS: Op-log created for az:// LIST operation"
+    echo "First 10 lines of op-log:"
+    zstd -dc /tmp/test_op_log_azure_list.tsv.zst | head -10
+  else
+    echo "INFO: No Azure test performed"
+  fi
+else
+  echo "SKIPPED: No Azure credentials available (AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_ACCESS_KEY not set)"
+fi
+
+echo ""
+echo "========================================"
+echo "All op-log tests completed successfully"
+echo "========================================"
+
+# Show summary of all log files created
+echo ""
+echo "Op-log files created:"
+ls -lh /tmp/test_op_log_*.tsv.zst 2>/dev/null || echo "No log files found"
+
+# Show detailed sample of a log file (decompressed)
+if [ -f /tmp/test_op_log_file_mixed.tsv.zst ]; then
+  echo ""
+  echo "========================================"
+  echo "Detailed op-log analysis (file:// backend)"
+  echo "========================================"
+  echo "TSV Format: idx thread op client_id n_objects bytes endpoint file error start first_byte end duration_ns"
+  echo ""
+  zstd -dc /tmp/test_op_log_file_mixed.tsv.zst | head -30
+  echo ""
+  echo "... (showing first 30 lines)"
+  echo ""
+  echo "Log file statistics:"
+  echo "  Compressed size: $(ls -lh /tmp/test_op_log_file_mixed.tsv.zst | awk '{print $5}')"
+  echo "  Uncompressed size: $(zstd -dc /tmp/test_op_log_file_mixed.tsv.zst | wc -c) bytes"
+  echo "  Total operations: $(zstd -dc /tmp/test_op_log_file_mixed.tsv.zst | tail -n +2 | wc -l)"
+  echo "  Operation types:"
+  echo "    - LIST: $(zstd -dc /tmp/test_op_log_file_mixed.tsv.zst | grep -c LIST || echo 0)"
+fi
+
+# Cleanup
+echo ""
+echo "Cleaning up test files..."
+rm -rf /tmp/s3dlio_test_oplog_file
+rm -rf /tmp/s3dlio_test_oplog_direct
+rm -f /tmp/test_op_log_*.tsv.zst
+
+echo "Done"

--- a/tests/test_python_oplog.py
+++ b/tests/test_python_oplog.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Test Python API op-log functionality for file:// and direct:// backends.
+Tests PUT and GET operations (not LIST, which isn't implemented for file backends yet).
+"""
+
+import os
+import sys
+import tempfile
+import shutil
+from pathlib import Path
+
+def main():
+    print("=" * 60)
+    print("Python API Op-Log Test (file:// and direct:// backends)")
+    print("=" * 60)
+    
+    # Import s3dlio
+    import s3dlio
+    
+    # Create temporary directories
+    src_dir = tempfile.mkdtemp(prefix="s3dlio_src_")
+    dest_file_dir = tempfile.mkdtemp(prefix="s3dlio_dest_file_")
+    dest_direct_dir = tempfile.mkdtemp(prefix="s3dlio_dest_direct_")
+    download_dir = tempfile.mkdtemp(prefix="s3dlio_download_")
+    
+    print(f"\n1. Creating test environment...")
+    print(f"   Source: {src_dir}")
+    print(f"   Dest (file://): {dest_file_dir}")
+    print(f"   Dest (direct://): {dest_direct_dir}")
+    print(f"   Download: {download_dir}")
+    
+    try:
+        # Create test files to upload
+        print(f"\n2. Creating 10 test files...")
+        for i in range(10):
+            test_file = os.path.join(src_dir, f"test_{i:03d}.dat")
+            with open(test_file, 'wb') as f:
+                # Write 10KB of data
+                f.write(b'X' * (10 * 1024))
+        print(f"   Created 10 test files (10KB each)")
+        
+        # Initialize op-log
+        log_path = "/tmp/test_op_log_python.tsv.zst"
+        if os.path.exists(log_path):
+            os.remove(log_path)
+        
+        print(f"\n3. Initializing op-log: {log_path}")
+        s3dlio.init_op_log(log_path)
+        
+        print("4. Checking if op-log is active...")
+        if s3dlio.is_op_log_active():
+            print("   ✓ Op-log is ACTIVE")
+        else:
+            print("   ✗ Op-log is NOT active")
+            return 1
+        
+        # Test file:// backend - PUT operations
+        print("\n5. Testing file:// backend - 10 PUT operations...")
+        file_uri = f"file://{dest_file_dir}/"
+        src_pattern = os.path.join(src_dir, "*.dat")
+        s3dlio.upload(
+            src_patterns=[src_pattern],
+            dest_prefix=file_uri,
+            max_in_flight=4,
+            create_bucket=False
+        )
+        print(f"   ✓ Uploaded 10 files to {file_uri}")
+        
+        # Test file:// backend - GET operations
+        print("\n6. Testing file:// backend - 10 GET operations...")
+        download_file_dir = os.path.join(download_dir, "from_file")
+        os.makedirs(download_file_dir, exist_ok=True)
+        
+        # Download with wildcard pattern
+        src_uri = f"file://{dest_file_dir}/"
+        s3dlio.download(
+            src_uri=src_uri,
+            dest_dir=download_file_dir,
+            max_in_flight=4,
+            recursive=True
+        )
+        print(f"   ✓ Downloaded files from {file_uri}")
+        
+        # Test direct:// backend - PUT operations  
+        print("\n7. Testing direct:// backend - 10 PUT operations...")
+        direct_uri = f"direct://{dest_direct_dir}/"
+        s3dlio.upload(
+            src_patterns=[src_pattern],
+            dest_prefix=direct_uri,
+            max_in_flight=4,
+            create_bucket=False
+        )
+        print(f"   ✓ Uploaded 10 files to {direct_uri}")
+        
+        # Test direct:// backend - GET operations
+        print("\n8. Testing direct:// backend - 10 GET operations...")
+        download_direct_dir = os.path.join(download_dir, "from_direct")
+        os.makedirs(download_direct_dir, exist_ok=True)
+        
+        # Download with wildcard pattern
+        src_uri = f"direct://{dest_direct_dir}/"
+        s3dlio.download(
+            src_uri=src_uri,
+            dest_dir=download_direct_dir,
+            max_in_flight=4,
+            recursive=True
+        )
+        print(f"   ✓ Downloaded files from {direct_uri}")
+        
+        # Finalize op-log
+        print("\n9. Finalizing op-log...")
+        s3dlio.finalize_op_log()
+        print("   ✓ Op-log finalized")
+        
+        # Verify log file was created
+        print("\n10. Verifying log file...")
+        if not os.path.exists(log_path):
+            print(f"   ✗ Log file not created: {log_path}")
+            return 1
+        
+        file_size = os.path.getsize(log_path)
+        print(f"   ✓ Log file created: {log_path} ({file_size} bytes)")
+        
+        # Decompress and show sample entries
+        print("\n11. Sample log entries:")
+        import subprocess
+        result = subprocess.run(
+            ['zstdcat', log_path],
+            capture_output=True,
+            text=True
+        )
+        
+        if result.returncode == 0:
+            lines = result.stdout.strip().split('\n')
+            print(f"   Total log entries: {len(lines)}")
+            
+            # Show header
+            if len(lines) > 0:
+                print(f"\n   Header:")
+                print(f"   {lines[0]}")
+            
+            # Show first few entries
+            if len(lines) > 1:
+                print(f"\n   First 5 entries:")
+                for line in lines[1:6]:
+                    print(f"   {line}")
+            
+            # Count operations by type
+            puts = sum(1 for line in lines[1:] if '\tPUT\t' in line)
+            gets = sum(1 for line in lines[1:] if '\tGET\t' in line)
+            
+            print(f"\n   Operation summary:")
+            print(f"   - PUT operations: {puts}")
+            print(f"   - GET operations: {gets}")
+            print(f"   - Total operations: {puts + gets}")
+            
+            # Check for file:// and direct:// endpoints
+            file_ops = sum(1 for line in lines[1:] if '\tfile://' in line)
+            direct_ops = sum(1 for line in lines[1:] if '\tdirect://' in line)
+            
+            print(f"\n   Backend summary:")
+            print(f"   - file:// operations: {file_ops}")
+            print(f"   - direct:// operations: {direct_ops}")
+        else:
+            print(f"   ⚠ Could not decompress log file: {result.stderr}")
+        
+        print("\n" + "=" * 60)
+        print("✓ All tests passed successfully")
+        print("=" * 60)
+        
+        return 0
+        
+    except Exception as e:
+        print(f"\n✗ Test failed with error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+        
+    finally:
+        # Cleanup
+        print(f"\n12. Cleaning up temporary directories...")
+        for d in [src_dir, dest_file_dir, dest_direct_dir, download_dir]:
+            if os.path.exists(d):
+                shutil.rmtree(d)
+        print("   ✓ Cleanup complete")
+
+if __name__ == "__main__":
+    exit(main())


### PR DESCRIPTION
Extends operation trace logging from S3-only to all backends (file://, s3://, az://, direct://). Enables performance profiling and debugging for any storage system.

Core Changes:
- NEW: src/object_store_logger.rs (373 lines) - LoggedObjectStore wrapper
- MODIFIED: src/object_store.rs - Generic functions use global_logger()
- MODIFIED: src/python_api/python_core_api.rs - Exposed init_op_log/finalize_op_log/is_op_log_active
- MODIFIED: src/bin/cli.rs - CLI uses logger-aware stores
- MODIFIED: src/api.rs - Exported logger factory functions
- MODIFIED: src/lib.rs - Added object_store_logger module

Features:
- LoggedObjectStore wrapper (decorator pattern) for non-invasive logging
- All operations logged: PUT, GET, LIST, DELETE with timing
- TSV format (zstd-compressed) compatible with warp-replay
- Thread-safe channel-based logging
- Zero overhead when not initialized
- Clean file paths (URI schemes stripped from file column)

APIs:
- Rust: store_for_uri_with_logger(), global_logger()
- Python: init_op_log(), finalize_op_log(), is_op_log_active()
- CLI: --op-log flag works with all commands

Testing:
- 74 Rust tests passing (zero warnings)
- Python API test: 43 operations (20 PUT + 20 GET + 3 LIST)
- Rust example: 110 operations across file:// and direct:// backends

Documentation:
- Updated docs/Changelog.md with v0.8.12 release notes
- Updated docs/api/python-api-v0.8.12-current.md with op-log section
- Updated README.md with badges (build, tests, version, license)
- Resolved docs/ISSUE-op-log-backend-support.md

Version: 0.8.12