### PR TITLE
feat: Add clock offset and generic data generation algorithm  (v0.9.21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,7 +5092,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.20"
+version = "0.9.21"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.20"
+version = "0.9.21"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "AGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
 [![Tests](https://img.shields.io/badge/tests-162%20passing-brightgreen)](docs/Changelog.md)
 [![Rust Tests](https://img.shields.io/badge/rust%20tests-162%2F162-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.20-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Version](https://img.shields.io/badge/version-0.9.21-blue)](https://github.com/russfellows/s3dlio/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
 [![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org)
@@ -11,6 +11,40 @@
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
 
 ## 🌟 Latest Release
+
+### v0.9.21 - Clock Offset Support & Pseudo-Random Data Generation (November 25, 2025)
+
+**🆕 New Features:**
+
+**Clock Offset Support for Distributed Op-Log Synchronization**
+- Enable accurate global timeline reconstruction when agents have clock skew
+- Thread-safe timestamp correction with minimal overhead
+- Essential for distributed benchmarking (sai3-bench, dl-driver)
+
+```rust
+// Initialize logger
+s3dlio::init_op_logger("operations.log.zst")?;
+
+// Calculate clock offset during agent sync
+let offset = (local_time - controller_time).as_nanos() as i64;
+
+// Set offset for all future log entries
+s3dlio::set_clock_offset(offset)?;
+```
+
+**Pseudo-Random Data Generation Method**
+- Added `generate_controlled_data_prand()` for CPU-efficient data generation
+- Performance: prand ~3-4 GB/s (consistent), random ~1-7 GB/s (variable)
+- Choose based on needs: `prand` for speed, `random` for true incompressibility
+
+**Issues Resolved:**
+- #100: Clock offset support implemented
+- #98: Old data generation code now serves as "prand" method
+- #95: Range Engine messages confirmed at trace level (already fixed)
+
+See [Changelog](docs/Changelog.md) for complete details.
+
+---
 
 ### v0.9.20 - High-Performance List & Delete Optimizations (November 22, 2025)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,58 @@
 # s3dlio Changelog
 
+## Version 0.9.21 - Clock Offset Support & Pseudo-Random Data Generation (November 25, 2025)
+
+### 🆕 **New Features**
+
+**Clock Offset Support for Distributed Op-Log Synchronization** (Issue #100)
+- Added `set_clock_offset()` and `get_clock_offset()` public functions
+- Logger now supports timestamp correction for distributed systems
+- Enables accurate global timeline reconstruction when agents have clock skew
+- Thread-safe implementation using `Arc<AtomicI64>`
+- Minimal overhead: single atomic read per log entry
+- Use case: sai3-bench and dl-driver distributed benchmarking
+
+API Usage:
+```rust
+// Initialize logger
+s3dlio::init_op_logger("operations.log.zst")?;
+
+// Calculate clock offset during agent sync
+let offset = (local_time - controller_time).as_nanos() as i64;
+
+// Set offset for all future log entries
+s3dlio::set_clock_offset(offset)?;
+```
+
+**Pseudo-Random Data Generation Method** (Issue #98 resolution)
+- Added `generate_controlled_data_prand()` function
+- Uses original BASE_BLOCK algorithm (~3-4 GB/s, consistent performance)
+- Provides "prand" option alongside "random" (new Xoshiro256++ algorithm)
+- Public API in `s3dlio::api::advanced` module
+- When to use:
+  - `random`: Truly incompressible data (compress=1 → ~1.0 zstd ratio), slower but more realistic
+  - `prand`: Maximum CPU efficiency, faster but allows cross-block compression patterns
+
+### ✅ **Bug Fixes & Improvements**
+
+**Issue #95: Range Engine Messages** (Already Fixed)
+- Confirmed Range Engine messages now at `trace!` level (not `debug!`)
+- Fixed in commit edee657 (November 16, 2025)
+- No longer overwhelms debug output
+
+**Issue #98: Old Data Generation Code**
+- Resolution: Old code now serves as "prand" method, not removed
+- Provides performance option for CPU-constrained scenarios
+- Both algorithms available for different use cases
+
+### 📝 **Documentation**
+
+- Added comprehensive clock offset documentation in `s3_logger.rs`
+- Updated API documentation for both data generation methods
+- Added usage examples for distributed op-log synchronization
+
+---
+
 ## Version 0.9.20 - High-Performance List & Delete Optimizations (November 22, 2025)
 
 ### 🚀 **Performance Improvements for Large Object Operations**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.9.20"
+version = "0.9.21"
 description = "High-performance S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/tests/test_data_gen_methods.py
+++ b/python/tests/test_data_gen_methods.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""
+Test script to verify data generation methods in s3dlio Python API.
+Tests: default (random), explicit random, and explicit prand methods.
+"""
+
+import s3dlio
+import time
+import os
+import shutil
+from pathlib import Path
+
+# Test configuration
+TEST_DIR = "/tmp/s3dlio_test_data_gen"
+NUM_OBJECTS = 10
+OBJECT_SIZE = 1024 * 1024  # 1 MB
+MAX_IN_FLIGHT = 4
+
+def setup_test_dir():
+    """Create clean test directory."""
+    if os.path.exists(TEST_DIR):
+        shutil.rmtree(TEST_DIR)
+    os.makedirs(TEST_DIR, exist_ok=True)
+    print(f"✓ Created test directory: {TEST_DIR}")
+
+def cleanup_test_dir():
+    """Remove test directory."""
+    if os.path.exists(TEST_DIR):
+        shutil.rmtree(TEST_DIR)
+    print(f"✓ Cleaned up test directory")
+
+def test_default_method():
+    """Test PUT with default data generation method (should be 'random')."""
+    print("\n" + "="*70)
+    print("TEST 1: Default data generation method (random)")
+    print("="*70)
+    
+    prefix = f"file://{TEST_DIR}/default/"
+    
+    start = time.time()
+    s3dlio.put(
+        prefix=prefix,
+        num=NUM_OBJECTS,
+        template="object-{}.dat",
+        max_in_flight=MAX_IN_FLIGHT,
+        size=OBJECT_SIZE,
+        object_type="raw",
+        dedup_factor=1,
+        compress_factor=1
+        # Note: NOT specifying data_gen_algorithm - should default to "random"
+    )
+    elapsed = time.time() - start
+    
+    # Verify files were created
+    files = list(Path(f"{TEST_DIR}/default").glob("*.dat"))
+    print(f"✓ Created {len(files)} objects in {elapsed:.3f}s")
+    print(f"✓ Throughput: {(NUM_OBJECTS * OBJECT_SIZE / 1024**2) / elapsed:.2f} MB/s")
+    
+    assert len(files) == NUM_OBJECTS, f"Expected {NUM_OBJECTS} files, got {len(files)}"
+    print("✓ Test PASSED")
+
+def test_explicit_random():
+    """Test PUT with explicit 'random' data generation method."""
+    print("\n" + "="*70)
+    print("TEST 2: Explicit 'random' data generation method")
+    print("="*70)
+    
+    prefix = f"file://{TEST_DIR}/random/"
+    
+    start = time.time()
+    s3dlio.put(
+        prefix=prefix,
+        num=NUM_OBJECTS,
+        template="object-{}.dat",
+        max_in_flight=MAX_IN_FLIGHT,
+        size=OBJECT_SIZE,
+        object_type="raw",
+        dedup_factor=1,
+        compress_factor=1,
+        data_gen_algorithm="random"  # Explicitly specify random
+    )
+    elapsed = time.time() - start
+    
+    # Verify files were created
+    files = list(Path(f"{TEST_DIR}/random").glob("*.dat"))
+    print(f"✓ Created {len(files)} objects in {elapsed:.3f}s")
+    print(f"✓ Throughput: {(NUM_OBJECTS * OBJECT_SIZE / 1024**2) / elapsed:.2f} MB/s")
+    
+    assert len(files) == NUM_OBJECTS, f"Expected {NUM_OBJECTS} files, got {len(files)}"
+    print("✓ Test PASSED")
+
+def test_explicit_prand():
+    """Test PUT with explicit 'prand' data generation method."""
+    print("\n" + "="*70)
+    print("TEST 3: Explicit 'prand' data generation method")
+    print("="*70)
+    
+    prefix = f"file://{TEST_DIR}/prand/"
+    
+    start = time.time()
+    s3dlio.put(
+        prefix=prefix,
+        num=NUM_OBJECTS,
+        template="object-{}.dat",
+        max_in_flight=MAX_IN_FLIGHT,
+        size=OBJECT_SIZE,
+        object_type="raw",
+        dedup_factor=1,
+        compress_factor=1,
+        data_gen_algorithm="prand"  # Explicitly specify prand
+    )
+    elapsed = time.time() - start
+    
+    # Verify files were created
+    files = list(Path(f"{TEST_DIR}/prand").glob("*.dat"))
+    print(f"✓ Created {len(files)} objects in {elapsed:.3f}s")
+    print(f"✓ Throughput: {(NUM_OBJECTS * OBJECT_SIZE / 1024**2) / elapsed:.2f} MB/s")
+    
+    assert len(files) == NUM_OBJECTS, f"Expected {NUM_OBJECTS} files, got {len(files)}"
+    print("✓ Test PASSED")
+
+def test_prand_with_streaming():
+    """Test PUT with prand + streaming mode."""
+    print("\n" + "="*70)
+    print("TEST 4: 'prand' with 'streaming' mode")
+    print("="*70)
+    
+    prefix = f"file://{TEST_DIR}/prand_streaming/"
+    
+    start = time.time()
+    s3dlio.put(
+        prefix=prefix,
+        num=NUM_OBJECTS,
+        template="object-{}.dat",
+        max_in_flight=MAX_IN_FLIGHT,
+        size=OBJECT_SIZE,
+        object_type="raw",
+        dedup_factor=1,
+        compress_factor=1,
+        data_gen_algorithm="prand",
+        data_gen_mode="streaming"  # Combine prand with streaming
+    )
+    elapsed = time.time() - start
+    
+    # Verify files were created
+    files = list(Path(f"{TEST_DIR}/prand_streaming").glob("*.dat"))
+    print(f"✓ Created {len(files)} objects in {elapsed:.3f}s")
+    print(f"✓ Throughput: {(NUM_OBJECTS * OBJECT_SIZE / 1024**2) / elapsed:.2f} MB/s")
+    
+    assert len(files) == NUM_OBJECTS, f"Expected {NUM_OBJECTS} files, got {len(files)}"
+    print("✓ Test PASSED")
+
+def main():
+    """Run all tests."""
+    print("="*70)
+    print("s3dlio Data Generation Methods Test Suite")
+    print("="*70)
+    print(f"Configuration:")
+    print(f"  - Objects per test: {NUM_OBJECTS}")
+    print(f"  - Object size: {OBJECT_SIZE / 1024**2:.1f} MB")
+    print(f"  - Max in-flight: {MAX_IN_FLIGHT}")
+    print(f"  - Test directory: {TEST_DIR}")
+    
+    try:
+        setup_test_dir()
+        
+        # Run all tests
+        test_default_method()
+        test_explicit_random()
+        test_explicit_prand()
+        test_prand_with_streaming()
+        
+        # Summary
+        print("\n" + "="*70)
+        print("ALL TESTS PASSED ✓")
+        print("="*70)
+        print("\nSummary:")
+        print("  ✓ Default method (random) works")
+        print("  ✓ Explicit 'random' method works")
+        print("  ✓ Explicit 'prand' method works")
+        print("  ✓ Combined 'prand' + 'streaming' mode works")
+        
+    except Exception as e:
+        print(f"\n❌ TEST FAILED: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+    finally:
+        cleanup_test_dir()
+    
+    return 0
+
+if __name__ == "__main__":
+    exit(main())

--- a/src/api/advanced.rs
+++ b/src/api/advanced.rs
@@ -94,5 +94,8 @@ pub use crate::s3_utils::get_object_concurrent_range;
 pub use crate::profiling::*;
 
 // Data generation utilities
-/// Generate test data with controlled characteristics
+/// Generate test data with controlled characteristics (new algorithm - high randomness)
 pub use crate::data_gen::generate_controlled_data;
+
+/// Generate test data with pseudo-random method (old algorithm - high performance)
+pub use crate::data_gen::generate_controlled_data_prand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ mod multipart;
 // ===== Legacy Re-exports for Backward Compatibility =====
 // These maintain compatibility with existing code but may be deprecated
 pub use data_gen::generate_controlled_data;
+pub use data_gen::generate_controlled_data_prand;  // Pseudo-random (fast) method
 
 // ===== Re-exports expected by tests/test_dataloader.rs at the crate root =====
 // Types:
@@ -171,7 +172,7 @@ pub use crate::multipart::{
 pub use crate::config::ObjectType;
 
 // logger helpers:
-pub use crate::s3_logger::{init_op_logger, finalize_op_logger};
+pub use crate::s3_logger::{init_op_logger, finalize_op_logger, set_clock_offset, get_clock_offset};
 
 
 // Bring in Python wrappers from python_api.rs when building as extension.


### PR DESCRIPTION
 # s3dlio v0.9.21 - Clock Offset and Data Generation Algorithm Selection

## Overview

This PR adds two major features to s3dlio:
1. **Clock offset support** for distributed op-log synchronization
2. **Generic data generation algorithm selection** with separate control over algorithm and mode

## Features Added

### 1. Clock Offset Support for Distributed Systems

**Problem:** Distributed agents with clock skew cannot accurately merge op-logs for chronological analysis.

**Solution:** Thread-safe clock offset correction applied at log write time.

**Implementation:**
- `Arc<AtomicI64> clock_offset_nanos` in Logger (minimal overhead)
- Public APIs: `set_clock_offset(i64)` and `get_clock_offset() -> i64`
- Timestamps automatically corrected: `corrected = original + offset`
- Python bindings included

**Use case:** sai3-bench and dl-driver distributed benchmarking with op-log merging

**Resolves:** #100

### 2. Generic Data Generation Algorithm Selection

**Problem:** Users need fine-grained control over data generation performance characteristics.

**Solution:** Separate algorithm choice (Random vs Prand) from generation mode (Streaming vs SinglePass).

**Implementation:**
- New `DataGenAlgorithm` enum: `Random`, `Prand`
- Existing `DataGenMode` enum unchanged: `Streaming`, `SinglePass`
- Config struct now has both `data_gen_algorithm` and `data_gen_mode` fields
- Python API: `data_gen_algorithm` parameter (defaults to `"random"`)

**Algorithm characteristics:**
- **Random**: Variable 1-7 GB/s depending on size (newer method, better quality)
- **Prand**: Consistent 3-4 GB/s (BASE_BLOCK algorithm, CPU-efficient)

**Python usage:**
```python
# Default: uses random algorithm
s3dlio.put("file:///data/", num=100)

# Explicit prand for consistent performance
s3dlio.put("file:///data/", num=100, data_gen_algorithm="prand")

# Combine with modes
s3dlio.put("file:///data/", num=100, 
           data_gen_algorithm="prand", 
           data_gen_mode="single-pass")
```

**Resolves:** #98 (old code now serves as prand method, not removed)

### 3. Additional Improvements

- **Issue #95 verified fixed:** Range Engine messages moved to trace level (commit edee657, Nov 16)
- **API version compatibility:** Fixed to use proper semantic versioning (major.minor must match)
- **Python test suite:** Comprehensive tests for all data generation methods
- **Documentation:** Updated Changelog and README with all features

## Testing

### Rust Tests
- ✅ 162 unit tests pass
- ✅ Zero compiler warnings (except deprecated list_objects)
- ✅ Clippy clean (minor doc comment warnings only)
- ✅ Release build successful

### Python Tests
- ✅ Test 1: Default method (random) - 864 MB/s
- ✅ Test 2: Explicit random - 2622 MB/s
- ✅ Test 3: Explicit prand - 2017 MB/s
- ✅ Test 4: Prand + streaming - 2214 MB/s

All tests create files successfully and verify correct operation.

## Files Changed

**13 files changed:** 523 insertions, 41 deletions

### Core Implementation
- `src/config.rs` - Added DataGenAlgorithm enum and with_data_gen_algorithm()
- `src/data_gen.rs` - Updated generate_object() to use both algorithm and mode
- `src/s3_logger.rs` - Added clock_offset_nanos field and correction logic

### API
- `src/api.rs` - Fixed version compatibility, exported clock offset functions
- `src/api/advanced.rs` - Exported prand function
- `src/lib.rs` - Exported new public APIs

### Python Bindings
- `src/python_api/python_core_api.rs` - Added data_gen_algorithm parameter to put functions

### Documentation
- `docs/Changelog.md` - Complete v0.9.21 section
- `README.md` - Updated version badge and features

### Testing
- `python/tests/test_data_gen_methods.py` - Comprehensive test suite (NEW)

### Version
- `Cargo.toml` - Version 0.9.21
- `pyproject.toml` - Version 0.9.21

## Breaking Changes

**None.** This release is fully backwards compatible.

## Backwards Compatibility

✅ Existing code continues to work without changes
✅ Python API defaults maintain current behavior (random algorithm)
✅ All existing tests pass
✅ New fields have sensible defaults

## Migration Guide

No migration needed. To use new features:

### Rust
```rust
use s3dlio::{set_clock_offset, get_clock_offset};

// Set clock offset (e.g., from NTP sync)
set_clock_offset(1_500_000); // 1.5ms correction

// Use prand algorithm
let config = Config::new_with_defaults(...)
    .with_data_gen_algorithm(DataGenAlgorithm::Prand)
    .with_data_gen_mode(DataGenMode::SinglePass);
```

### Python
```python
import s3dlio

# Use prand for consistent performance
s3dlio.put("file:///data/", num=1000, data_gen_algorithm="prand")
```

## Checklist

- [x] All tests pass
- [x] Documentation updated
- [x] Changelog updated
- [x] Version bumped (0.9.21)
- [x] Python bindings tested
- [x] No breaking changes
- [x] Backwards compatible
- [x] Issues referenced (#100, #98, #95)

## Related Issues

- Closes #100 (Clock offset support)
- Closes #98 (Old data generation code - now prand method)
- References #95 (Range Engine trace logging - already fixed)

## Next Steps After Merge

1. Tag release: `git tag -a v0.9.21 -m "Release v0.9.21"`
2. Push tag: `git push origin v0.9.21`
3. Create GitHub release with notes
4. Update downstream projects (sai3-bench, dl-driver)