### PR TITLE
feat: Add endpoint support for Azure Blob and GCS backends 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5092,7 +5092,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.21"
+version = "0.9.23"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.21"
+version = "0.9.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.22"
+version = "0.9.23"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "AGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # s3dlio - Universal Storage I/O Library
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
-[![Tests](https://img.shields.io/badge/tests-162%20passing-brightgreen)](docs/Changelog.md)
-[![Rust Tests](https://img.shields.io/badge/rust%20tests-162%2F162-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.22-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Tests](https://img.shields.io/badge/tests-175%20passing-brightgreen)](docs/Changelog.md)
+[![Rust Tests](https://img.shields.io/badge/rust%20tests-175%2F175-brightgreen)](docs/Changelog.md)
+[![Version](https://img.shields.io/badge/version-0.9.23-blue)](https://github.com/russfellows/s3dlio/releases)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
 [![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org)
@@ -11,6 +11,47 @@
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
 
 ## 🌟 Latest Release
+
+### v0.9.23 - Azure Blob & GCS Custom Endpoint Support (December 3, 2025)
+
+**🆕 New Features:**
+
+**Custom Endpoint Support for Azure Blob Storage**
+- Added environment variable support for custom Azure endpoints
+- Primary: `AZURE_STORAGE_ENDPOINT` (e.g., `http://localhost:10000`)
+- Alternative: `AZURE_BLOB_ENDPOINT_URL`
+- Enables use with Azurite, WarpIO, or other Azure-compatible emulators/proxies
+
+```bash
+# Azurite (local emulator)
+export AZURE_STORAGE_ENDPOINT=http://127.0.0.1:10000
+sai3-bench util ls az://devstoreaccount1/testcontainer/
+
+# WarpIO multi-protocol proxy
+export AZURE_STORAGE_ENDPOINT=http://localhost:9001
+sai3-bench util ls az://myaccount/mycontainer/
+```
+
+**Custom Endpoint Support for Google Cloud Storage**
+- Primary: `GCS_ENDPOINT_URL` (e.g., `http://localhost:4443`)
+- Alternative: `STORAGE_EMULATOR_HOST` (GCS emulator convention)
+- Enables use with fake-gcs-server, WarpIO, or other GCS-compatible emulators
+
+```bash
+# fake-gcs-server (local emulator)
+export GCS_ENDPOINT_URL=http://localhost:4443
+sai3-bench util ls gs://testbucket/
+
+# Using STORAGE_EMULATOR_HOST convention
+export STORAGE_EMULATOR_HOST=localhost:4443
+sai3-bench util ls gs://testbucket/
+```
+
+**Related Issue:** [sai3-bench#56](https://github.com/russfellows/sai3-bench/issues/56)
+
+See [Changelog](docs/Changelog.md) for complete details.
+
+---
 
 ### v0.9.22 - Client ID & First Byte Tracking (November 25, 2025)
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,69 @@
 # s3dlio Changelog
 
+## Version 0.9.23 - Azure Blob & GCS Custom Endpoint Support (December 3, 2025)
+
+### 🆕 **New Features**
+
+**Custom Endpoint Support for Azure Blob Storage**
+- Added environment variable support for custom Azure endpoints
+- Primary: `AZURE_STORAGE_ENDPOINT` (e.g., `http://localhost:10000`)
+- Alternative: `AZURE_BLOB_ENDPOINT_URL`
+- Enables use with Azurite, WarpIO, or other Azure-compatible emulators/proxies
+- Account name is appended to endpoint URL automatically
+
+Usage:
+```bash
+# Azurite (local emulator)
+export AZURE_STORAGE_ENDPOINT=http://127.0.0.1:10000
+sai3-bench util ls az://devstoreaccount1/testcontainer/
+
+# WarpIO multi-protocol proxy
+export AZURE_STORAGE_ENDPOINT=http://localhost:9001
+sai3-bench util ls az://myaccount/mycontainer/
+```
+
+**Custom Endpoint Support for Google Cloud Storage**
+- Added environment variable support for custom GCS endpoints
+- Primary: `GCS_ENDPOINT_URL` (e.g., `http://localhost:4443`)
+- Alternative: `STORAGE_EMULATOR_HOST` (GCS emulator convention, `http://` prepended if missing)
+- Enables use with fake-gcs-server, WarpIO, or other GCS-compatible emulators/proxies
+- Anonymous authentication used automatically for custom endpoints (typical for emulators)
+
+Usage:
+```bash
+# fake-gcs-server (local emulator)
+export GCS_ENDPOINT_URL=http://localhost:4443
+sai3-bench util ls gs://testbucket/
+
+# Using STORAGE_EMULATOR_HOST convention
+export STORAGE_EMULATOR_HOST=localhost:4443
+sai3-bench util ls gs://testbucket/
+
+# WarpIO multi-protocol proxy
+export GCS_ENDPOINT_URL=http://localhost:9002
+sai3-bench util ls gs://testbucket/
+```
+
+### 📝 **Documentation**
+
+- Updated `docs/api/Environment_Variables.md` with Azure and GCS endpoint configuration
+- Added new constants in `src/constants.rs` for endpoint environment variable names:
+  - `ENV_AZURE_STORAGE_ENDPOINT`
+  - `ENV_AZURE_BLOB_ENDPOINT_URL`
+  - `ENV_GCS_ENDPOINT_URL`
+  - `ENV_STORAGE_EMULATOR_HOST`
+
+### ⚡ **Compatibility**
+
+**Backwards Compatibility**: No breaking changes
+- When environment variables are not set, behavior remains identical to previous versions
+- Connects to public cloud endpoints by default (Azure Blob, GCS)
+- S3 custom endpoint support via `AWS_ENDPOINT_URL` remains unchanged
+
+**Related Issue**: https://github.com/russfellows/sai3-bench/issues/56
+
+---
+
 ## Version 0.9.22 - Client ID & First Byte Tracking (November 25, 2025)
 
 ### 🆕 **New Features**

--- a/docs/api/Environment_Variables.md
+++ b/docs/api/Environment_Variables.md
@@ -45,8 +45,56 @@ Standard AWS environment variables are also supported:
 | `AWS_SECRET_ACCESS_KEY` | AWS secret key |
 | `AWS_SESSION_TOKEN` | AWS session token (for temporary credentials) |
 | `AWS_REGION` | AWS region (e.g., `us-east-1`) |
-| `AWS_ENDPOINT_URL` | Custom S3 endpoint URL |
+| `AWS_ENDPOINT_URL` | Custom S3 endpoint URL (for MinIO, WarpIO, or S3-compatible storage) |
 | `AWS_CA_BUNDLE_PATH` | Path to custom CA certificate bundle |
+
+## Azure Blob Storage Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `AZURE_STORAGE_ACCOUNT` | Azure storage account name |
+| `AZURE_STORAGE_KEY` | Azure storage account key |
+| `AZURE_CLIENT_ID` | Azure AD client ID (for service principal auth) |
+| `AZURE_CLIENT_SECRET` | Azure AD client secret |
+| `AZURE_TENANT_ID` | Azure AD tenant ID |
+| `AZURE_STORAGE_ENDPOINT` | **Custom Azure endpoint** (e.g., `http://localhost:10000` for Azurite or WarpIO) |
+| `AZURE_BLOB_ENDPOINT_URL` | Alternative for `AZURE_STORAGE_ENDPOINT` |
+
+### Azure Custom Endpoint Examples
+
+```bash
+# Azurite (local emulator)
+export AZURE_STORAGE_ENDPOINT=http://127.0.0.1:10000
+sai3-bench util ls az://devstoreaccount1/testcontainer/
+
+# WarpIO multi-protocol proxy
+export AZURE_STORAGE_ENDPOINT=http://localhost:9001
+sai3-bench util ls az://myaccount/mycontainer/
+```
+
+## Google Cloud Storage Configuration
+
+| Variable | Description |
+|----------|-------------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | Path to GCS service account JSON key file |
+| `GCS_ENDPOINT_URL` | **Custom GCS endpoint** (e.g., `http://localhost:4443` for fake-gcs-server or WarpIO) |
+| `STORAGE_EMULATOR_HOST` | GCS emulator convention (`host:port`), `http://` prepended if missing |
+
+### GCS Custom Endpoint Examples
+
+```bash
+# fake-gcs-server (local emulator)
+export GCS_ENDPOINT_URL=http://localhost:4443
+sai3-bench util ls gs://testbucket/
+
+# Using STORAGE_EMULATOR_HOST convention
+export STORAGE_EMULATOR_HOST=localhost:4443
+sai3-bench util ls gs://testbucket/
+
+# WarpIO multi-protocol proxy
+export GCS_ENDPOINT_URL=http://localhost:9002
+sai3-bench util ls gs://testbucket/
+```
 
 ## Usage Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.9.22"
+version = "0.9.23"
 description = "High-performance S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -221,6 +221,27 @@ pub const ENV_OPLOG_READ_BUF: &str = "S3DLIO_OPLOG_READ_BUF";
 /// Environment variable for op-log chunk size
 pub const ENV_OPLOG_CHUNK_SIZE: &str = "S3DLIO_OPLOG_CHUNK_SIZE";
 
+// =============================================================================
+// Custom Endpoint Environment Variables
+// =============================================================================
+
+/// Primary environment variable for custom Azure Blob Storage endpoint
+/// Example: AZURE_STORAGE_ENDPOINT=http://localhost:10000
+pub const ENV_AZURE_STORAGE_ENDPOINT: &str = "AZURE_STORAGE_ENDPOINT";
+
+/// Alternative environment variable for custom Azure Blob Storage endpoint
+/// Example: AZURE_BLOB_ENDPOINT_URL=http://localhost:10000
+pub const ENV_AZURE_BLOB_ENDPOINT_URL: &str = "AZURE_BLOB_ENDPOINT_URL";
+
+/// Primary environment variable for custom GCS endpoint
+/// Example: GCS_ENDPOINT_URL=http://localhost:4443
+pub const ENV_GCS_ENDPOINT_URL: &str = "GCS_ENDPOINT_URL";
+
+/// GCS emulator convention environment variable (STORAGE_EMULATOR_HOST=host:port)
+/// If value doesn't start with http://, "http://" is prepended automatically
+/// Example: STORAGE_EMULATOR_HOST=localhost:4443
+pub const ENV_STORAGE_EMULATOR_HOST: &str = "STORAGE_EMULATOR_HOST";
+
 /// A base random block of BLK_SIZE bytes, generated once and shared.
 /// Used by the single-pass data generation algorithm.
 pub static A_BASE_BLOCK: Lazy<Arc<Vec<u8>>> = Lazy::new(|| {


### PR DESCRIPTION

- Add AZURE_STORAGE_ENDPOINT and AZURE_BLOB_ENDPOINT_URL environment variables for custom Azure endpoints (Azurite, WarpIO, or other emulators/proxies)
- Add GCS_ENDPOINT_URL and STORAGE_EMULATOR_HOST environment variables for custom GCS endpoints (fake-gcs-server, WarpIO, or other emulators)
- Add resolve_azure_account_url() and resolve_gcs_endpoint() helper functions for testable endpoint resolution logic
- Add 13 new unit tests for endpoint environment variable handling
- Update Environment_Variables.md with new Azure and GCS configuration
- Update Changelog.md with v0.9.23 release notes
- Update version to 0.9.23 in Cargo.toml and pyproject.toml
- Update README.md badges (175 tests, version 0.9.23)

Related: sai3-bench#56