### PR TITLE
release: v0.9.27 - PyPI release with bug fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,7 +5101,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5178,7 +5178,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.26"
+version = "0.9.27"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "AGPL-3.0"

--- a/README.md
+++ b/README.md
@@ -3,25 +3,33 @@
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
 [![Tests](https://img.shields.io/badge/tests-175%20passing-brightgreen)](docs/Changelog.md)
 [![Rust Tests](https://img.shields.io/badge/rust%20tests-175%2F175-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.26-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Version](https://img.shields.io/badge/version-0.9.27-blue)](https://github.com/russfellows/s3dlio/releases)
+[![PyPI](https://img.shields.io/pypi/v/s3dlio)](https://pypi.org/project/s3dlio/)
 [![License](https://img.shields.io/badge/license-AGPL--3.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
 [![Python](https://img.shields.io/badge/python-3.8%2B-blue)](https://www.python.org)
 
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
 
+## 📦 Installation
+
+```bash
+pip install s3dlio
+```
+
 ## 🌟 Latest Release
 
-### v0.9.26 - DLIO Benchmark Integration (December 2025)
+### v0.9.27 - PyPI Release & DLIO Integration (December 2025)
 
-**🆕 New Features:**
+**First PyPI Release** - s3dlio is now available via `pip install s3dlio`
 
-**DLIO Benchmark Integration**
-- Added comprehensive integration support for [Argonne DLIO Benchmark](https://github.com/argonne-lcf/dlio_benchmark)
+**🆕 DLIO Benchmark Integration**
+- Comprehensive integration support for [Argonne DLIO Benchmark](https://github.com/argonne-lcf/dlio_benchmark)
 - Two installation options:
   - **Option 1 (Recommended):** New `storage_type: s3dlio` with explicit configuration
   - **Option 2:** Drop-in replacement for existing S3 configurations
 - Enables DLIO to use all s3dlio backends: S3, Azure, GCS, file://, direct://
+- See [DLIO Integration Guide](docs/integration/DLIO_BENCHMARK_INTEGRATION.md) for setup instructions
 
 **Zero-Copy Write Functions**
 ```python
@@ -34,10 +42,11 @@ s3dlio.put_bytes("s3://bucket/file.bin", data)
 s3dlio.mkdir("s3://bucket/my-prefix/")
 ```
 
-**Azure SDK Update**
-- Updated from Azure SDK 0.4.0 to 0.7.0 API
+**Bug Fixes**
+- Fixed optional imports (no crash without PyTorch/JAX/TensorFlow)
+- Fixed `exists_async()` and `stat_async()` to work with all backends
 
-See [Changelog](docs/Changelog.md) for complete details and [DLIO Integration Guide](docs/integration/DLIO_BENCHMARK_INTEGRATION.md) for setup instructions.
+See [Changelog](docs/Changelog.md) for complete details.
 
 ---
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,37 @@
 # s3dlio Changelog
 
+## Version 0.9.27 - PyPI Release & Bug Fixes (December 2025)
+
+### 🆕 **First PyPI Release**
+
+s3dlio is now available on PyPI! Install with:
+```bash
+pip install s3dlio
+```
+
+### 🐛 **Bug Fixes**
+
+**Optional ML Framework Imports**
+- Fixed crash when importing s3dlio without PyTorch/JAX/TensorFlow installed
+- ML-specific loaders (S3MapDataset, S3IterableDataset, etc.) now return `None` if frameworks unavailable
+- Core storage functions work without any ML dependencies
+
+**Universal Backend Support for Async Functions**
+- Fixed `exists_async()` to work with all backends (was S3-only)
+- Fixed `stat_async()` to work with all backends (was S3-only)
+- Both now use the universal ObjectStore interface like their sync counterparts
+
+### 📦 **Package Metadata**
+
+- Added author information: Russ Fellows
+- Proper package metadata for PyPI listing
+
+### ⚠️ **Note**
+
+v0.9.26 was yanked from PyPI due to the import bug. Use v0.9.27.
+
+---
+
 ## Version 0.9.26 - DLIO Benchmark Integration (December 2025)
 
 ### 🆕 **New Features**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,12 @@
 [project]
 name = "s3dlio"
-version = "0.9.26"
+version = "0.9.27"
 description = "High-performance S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = []
 license = { text = "AGPL-3.0" }
+authors = [{ name = "Russ Fellows", email = "russ.fellows@gmail.com" }]
 
 [build-system]
 requires = ["maturin>=0.12"]

--- a/python/s3dlio/__init__.py
+++ b/python/s3dlio/__init__.py
@@ -18,7 +18,14 @@ from importlib import import_module
 import sys as _sys
 from typing import List  # avoid confusion with Rust-exported `list` symbol
 
-from .torch import S3MapDataset, S3IterableDataset
+# PyTorch integration (optional - only import if torch is available)
+try:
+    from .torch import S3MapDataset, S3IterableDataset
+    _HAS_TORCH = True
+except ImportError:
+    _HAS_TORCH = False
+    S3MapDataset = None
+    S3IterableDataset = None
 
 # ------------------------------------------------------------------
 # 1) Import the native module and re-export *public* names
@@ -67,8 +74,16 @@ def stat_key(bucket: str, key: str) -> dict:
     return stat(f"s3://{bucket}/{key}")
 
 # ------------------------------------------------------------------
-# 3) high-level loaders (Rust engine only)
+# 3) high-level loaders (optional - only if frameworks are available)
 # ------------------------------------------------------------------
-from .torch  import S3IterableDataset     # noqa: E402
-from .jax_tf import S3JaxIterable, make_tf_dataset  # noqa: E402
+# PyTorch loaders - imported at top with try/except (S3MapDataset, S3IterableDataset)
+
+# JAX/TensorFlow loaders (optional)
+try:
+    from .jax_tf import S3JaxIterable, make_tf_dataset  # noqa: E402
+    _HAS_JAX_TF = True
+except ImportError:
+    _HAS_JAX_TF = False
+    S3JaxIterable = None
+    make_tf_dataset = None
 


### PR DESCRIPTION
Changes:
- Version bump to 0.9.27
- Fixed optional ML framework imports (torch/jax/tf)
- Fixed exists_async() to work with all backends (was S3-only)
- Fixed stat_async() to work with all backends (was S3-only)
- Added author metadata for PyPI
- Updated README with PyPI badge and installation instructions
- Updated Changelog with v0.9.27 release notes

Note: v0.9.26 was yanked from PyPI due to import bug