### PR TITLE
fix: Resolve FileSystemConfig type mismatch in API (Issue #85)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5100,7 +5100,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5177,7 +5177,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.31"
+version = "0.9.32"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.31"
+version = "0.9.32"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # s3dlio - Universal Storage I/O Library
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
-[![Tests](https://img.shields.io/badge/tests-175%20passing-brightgreen)](docs/Changelog.md)
-[![Rust Tests](https://img.shields.io/badge/rust%20tests-175%2F175-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.31-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Tests](https://img.shields.io/badge/tests-182%20passing-brightgreen)](docs/Changelog.md)
+[![Rust Tests](https://img.shields.io/badge/rust%20tests-182%2F182-brightgreen)](docs/Changelog.md)
+[![Version](https://img.shields.io/badge/version-0.9.32-blue)](https://github.com/russfellows/s3dlio/releases)
 [![PyPI](https://img.shields.io/pypi/v/s3dlio)](https://pypi.org/project/s3dlio/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
@@ -18,6 +18,16 @@ pip install s3dlio
 ```
 
 ## 🌟 Latest Release
+
+### v0.9.32 - Bug Fix: FileSystemConfig Type Mismatch (December 2025)
+
+**🐛 Fixed Issue #85**
+- Resolved type collision between `file_store::FileSystemConfig` and `file_store_direct::FileSystemConfig`
+- Introduced unified `StorageConfig` enum for type-safe configuration
+- Added debug logging for page cache mode application
+- 7 new comprehensive tests for API configuration scenarios
+
+**⚠️ Breaking Change**: `store_for_uri_with_config()` now requires `StorageConfig` wrapper
 
 ### v0.9.30 - Zero-Copy Refactor & PyO3 0.27 (December 2025)
 

--- a/examples/issue_85_reproduction.rs
+++ b/examples/issue_85_reproduction.rs
@@ -1,0 +1,72 @@
+// examples/issue_85_reproduction.rs
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// SPDX-FileCopyrightText: 2025 Russ Fellows <russ.fellows@gmail.com>
+
+//! Reproduction of Issue #85: FileSystemConfig Type Mismatch
+//!
+//! This example demonstrates the bug that existed in v0.9.31 and earlier:
+//! - The public API exported `crate::file_store::FileSystemConfig`
+//! - But `store_for_uri_with_config()` expected `crate::file_store_direct::FileSystemConfig`
+//! - Result: Code using the documented public API would not compile
+//!
+//! **Before Fix (v0.9.31)**: This would fail with:
+//! ```
+//! error[E0308]: mismatched types
+//! expected `s3dlio::file_store_direct::FileSystemConfig`
+//! found `s3dlio::file_store::FileSystemConfig`
+//! ```
+//!
+//! **After Fix (v0.9.32)**: This compiles and runs successfully!
+
+use anyhow::Result;
+use std::fs::File;
+use std::io::Write;
+use tempfile::TempDir;
+
+// This is what users would naturally write based on the public API documentation
+use s3dlio::api::{FileSystemConfig, PageCacheMode, StorageConfig, store_for_uri_with_config};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    println!("Issue #85 Reproduction Test");
+    println!("============================\n");
+    
+    // Create a test file
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Hello from Issue #85 test!")?;
+    drop(file);
+    
+    println!("✓ Created test file: {}", test_file.display());
+    
+    // Create FileSystemConfig with page_cache_mode - the feature users want to use
+    let config = FileSystemConfig {
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        page_cache_mode: Some(PageCacheMode::Sequential),
+    };
+    
+    println!("✓ Created FileSystemConfig with PageCacheMode::Sequential");
+    
+    // Before Fix (v0.9.31): This line would cause a compile error!
+    // After Fix (v0.9.32): This works!
+    let uri = format!("file://{}", test_file.display());
+    let store = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)))?;
+    
+    println!("✓ Successfully created store with config (this would have FAILED in v0.9.31)");
+    
+    // Verify it actually works
+    let data = store.get(&uri).await?;
+    assert_eq!(&data[..], b"Hello from Issue #85 test!");
+    
+    println!("✓ Successfully read data: {:?}", String::from_utf8_lossy(&data));
+    
+    println!("\n✅ SUCCESS! Issue #85 is FIXED!");
+    println!("\nIn v0.9.31 and earlier, this example would not even compile.");
+    println!("The compiler would complain about mismatched FileSystemConfig types.");
+    println!("Now it compiles and runs perfectly!\n");
+    
+    Ok(())
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,15 +1,30 @@
 [project]
 name = "s3dlio"
-version = "0.9.31"
+version = "0.9.32"
 description = "High-performance S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.12"
-dependencies = []
+dependencies = [
+    "numpy>=2.0.0",
+]
 license = { text = "Apache-2.0" }
 authors = [{ name = "Russ Fellows", email = "russ.fellows@gmail.com" }]
 
+[project.optional-dependencies]
+torch = ["torch>=2.0.0"]
+jax = ["jax>=0.4.0", "jaxlib>=0.4.0"]
+tensorflow = ["tensorflow>=2.16.0"]
+all = ["torch>=2.0.0", "jax>=0.4.0", "jaxlib>=0.4.0", "tensorflow>=2.16.0"]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "h5py>=3.0.0",
+    "maturin>=1.0.0",
+    "patchelf>=0.17.0",  # Required for maturin on Linux
+]
+
 [build-system]
-requires = ["maturin>=0.12"]
+requires = ["maturin>=1.0.0"]
 build-backend = "maturin"
 
 [tool.maturin]

--- a/src/api.rs
+++ b/src/api.rs
@@ -59,8 +59,24 @@ pub use crate::object_store::ObjectMetadata;
 /// FileSystem-specific configuration (page cache, range engine, etc.)
 pub use crate::file_store::FileSystemConfig;
 
+/// Direct I/O FileSystem configuration (O_DIRECT, alignment, etc.)
+pub use crate::file_store_direct::FileSystemConfig as DirectFileSystemConfig;
+
 /// Page cache behavior hint for file I/O (maps to posix_fadvise on Linux/Unix)
 pub use crate::data_loader::options::PageCacheMode;
+
+/// Unified storage configuration for all backends
+/// 
+/// Use this enum to configure backend-specific options when creating stores
+/// with `store_for_uri_with_config()`. This allows you to pass the correct
+/// configuration type for each storage backend (file://, direct://, etc.)
+#[derive(Debug, Clone)]
+pub enum StorageConfig {
+    /// Configuration for regular file:// URIs (page cache, range engine)
+    File(crate::file_store::FileSystemConfig),
+    /// Configuration for direct:// URIs and O_DIRECT operations
+    Direct(crate::file_store_direct::FileSystemConfig),
+}
 
 /// URI scheme detection
 pub use crate::object_store::{Scheme, infer_scheme};

--- a/src/file_store.rs
+++ b/src/file_store.rs
@@ -397,6 +397,7 @@ impl FileSystemObjectStore {
         
         // Apply page cache hint (use configured mode or Auto by default)
         let cache_mode = self.config.page_cache_mode.unwrap_or(PageCacheMode::Auto);
+        debug!("Applying page cache hint {:?} for file {} (size: {} bytes)", cache_mode, uri, file_size);
         let _ = apply_page_cache_hint(&std_file, cache_mode, file_size);
         
         // Convert back to tokio file and read
@@ -471,6 +472,8 @@ impl ObjectStore for FileSystemObjectStore {
         
         // Apply page cache hint (use configured mode, or Random for range reads by default)
         let cache_mode = self.config.page_cache_mode.unwrap_or(PageCacheMode::Random);
+        debug!("Applying page cache hint {:?} for range read {} offset={} length={:?} (file size: {} bytes)", 
+               cache_mode, uri, offset, length, file_size);
         let _ = apply_page_cache_hint(&std_file, cache_mode, file_size);
         
         let mut file = fs::File::from_std(std_file);

--- a/tests/test_api_storage_config.rs
+++ b/tests/test_api_storage_config.rs
@@ -1,0 +1,206 @@
+// tests/test_api_storage_config.rs
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// SPDX-FileCopyrightText: 2025 Russ Fellows <russ.fellows@gmail.com>
+
+//! Tests for unified StorageConfig API (Issue #85)
+//!
+//! This test validates that the FileSystemConfig type mismatch is fixed and
+//! that users can configure page cache mode via the public API.
+
+use anyhow::Result;
+use s3dlio::api::{
+    FileSystemConfig, DirectFileSystemConfig, StorageConfig,
+    PageCacheMode, store_for_uri_with_config,
+};
+use s3dlio::range_engine_generic::RangeEngineConfig;
+use std::time::Duration;
+use tempfile::TempDir;
+use std::fs::File;
+use std::io::Write;
+
+#[tokio::test]
+async fn test_file_config_public_api() -> Result<()> {
+    // Create temp directory with test file
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Hello, world!")?;
+    drop(file);
+    
+    // Create FileSystemConfig with page cache mode
+    let config = FileSystemConfig {
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        page_cache_mode: Some(PageCacheMode::Sequential),
+    };
+    
+    let uri = format!("file://{}", test_file.display());
+    
+    // This should compile and work now!
+    let store = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)))?;
+    
+    // Verify it works by reading the file
+    let data = store.get(&uri).await?;
+    assert_eq!(&data[..], b"Hello, world!");
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_config_random_mode() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Random access test data")?;
+    drop(file);
+    
+    let config = FileSystemConfig {
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        page_cache_mode: Some(PageCacheMode::Random),
+    };
+    
+    let uri = format!("file://{}", test_file.display());
+    let store = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)))?;
+    
+    let data = store.get(&uri).await?;
+    assert_eq!(&data[..], b"Random access test data");
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_config_auto_mode() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Auto mode test")?;
+    drop(file);
+    
+    let config = FileSystemConfig {
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        page_cache_mode: None,  // Auto mode (default)
+    };
+    
+    let uri = format!("file://{}", test_file.display());
+    let store = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)))?;
+    
+    let data = store.get(&uri).await?;
+    assert_eq!(&data[..], b"Auto mode test");
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_direct_config_not_for_file_uri() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Test data")?;
+    drop(file);
+    
+    // Create DirectFileSystemConfig
+    let config = DirectFileSystemConfig {
+        direct_io: true,
+        alignment: 4096,
+        min_io_size: 4096,
+        sync_writes: false,
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        buffer_pool: None,
+    };
+    
+    let uri = format!("file://{}", test_file.display());
+    
+    // This should fail with clear error message
+    let result = store_for_uri_with_config(&uri, Some(StorageConfig::Direct(config)));
+    
+    assert!(result.is_err());
+    if let Err(e) = result {
+        let err_msg = e.to_string();
+        assert!(err_msg.contains("Cannot use DirectFileSystemConfig with file://"));
+    }
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_file_config_not_for_direct_uri() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Test data")?;
+    drop(file);
+    
+    // Create FileSystemConfig
+    let config = FileSystemConfig {
+        enable_range_engine: false,
+        range_engine: Default::default(),
+        page_cache_mode: Some(PageCacheMode::Sequential),
+    };
+    
+    let uri = format!("direct://{}", test_file.display());
+    
+    // This should fail with clear error message
+    let result = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)));
+    
+    assert!(result.is_err());
+    if let Err(e) = result {
+        let err_msg = e.to_string();
+        assert!(err_msg.contains("Cannot use FileSystemConfig with direct://"));
+    }
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_no_config_still_works() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("test.txt");
+    let mut file = File::create(&test_file)?;
+    file.write_all(b"Default config test")?;
+    drop(file);
+    
+    let uri = format!("file://{}", test_file.display());
+    
+    // Should work with None config
+    let store = store_for_uri_with_config(&uri, None)?;
+    let data = store.get(&uri).await?;
+    assert_eq!(&data[..], b"Default config test");
+    
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_range_engine_with_page_cache() -> Result<()> {
+    let temp_dir = TempDir::new()?;
+    let test_file = temp_dir.path().join("large.txt");
+    let mut file = File::create(&test_file)?;
+    
+    // Create a larger file (1MB) to potentially trigger range engine
+    let data = vec![b'A'; 1024 * 1024];
+    file.write_all(&data)?;
+    drop(file);
+    
+    let config = FileSystemConfig {
+        enable_range_engine: true,
+        range_engine: RangeEngineConfig {
+            chunk_size: 256 * 1024,           // 256KB chunks
+            max_concurrent_ranges: 4,
+            min_split_size: 512 * 1024,       // 512KB threshold
+            range_timeout: Duration::from_secs(60),
+        },
+        page_cache_mode: Some(PageCacheMode::Sequential),
+    };
+    
+    let uri = format!("file://{}", test_file.display());
+    let store = store_for_uri_with_config(&uri, Some(StorageConfig::File(config)))?;
+    
+    let result = store.get(&uri).await?;
+    assert_eq!(result.len(), 1024 * 1024);
+    assert_eq!(result[0], b'A');
+    
+    Ok(())
+}


### PR DESCRIPTION
- Introduced unified StorageConfig enum to wrap both FileSystemConfig types
- Fixed store_for_uri_with_config() to accept StorageConfig instead of ambiguous FileSystemConfig
- Added type checking to prevent wrong config with wrong URI scheme
- Added debug logging for page cache mode being applied
- Created comprehensive tests for all configuration scenarios (7 new tests)
- Added reproduction example demonstrating the fix
- Updated README badges to reflect 182 passing tests
- Bumped version to 0.9.32

BREAKING CHANGE: store_for_uri_with_config() now requires StorageConfig enum wrapper
- FileSystemConfig -> StorageConfig::File(config) for file:// URIs
- DirectFileSystemConfig -> StorageConfig::Direct(config) for direct:// URIs

Closes #85