### PR TITLE
v0.9.95 — O_DIRECT fix in get_many(), BufferPool deadlock fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4984,7 +4984,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.94"
+version = "0.9.95"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5069,7 +5069,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.94"
+version = "0.9.95"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.94"
+version = "0.9.95"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
 [![Rust Tests](https://img.shields.io/badge/rust%20tests-580-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.94-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Version](https://img.shields.io/badge/version-0.9.95-blue)](https://github.com/russfellows/s3dlio/releases)
 [![PyPI](https://img.shields.io/pypi/v/s3dlio)](https://pypi.org/project/s3dlio/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
@@ -10,15 +10,13 @@
 
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
 
-> **v0.9.94 — Fast NPZ generation, zero-copy `BytesView` upload path, `write_bytes_blocking()`**
+> **v0.9.95 — O_DIRECT fix, BufferPool deadlock fix**
 >
-> **`generate_npz_bytes(shape, dtype, num_samples)`:** Builds a complete NumPy `.npz` archive in Rust without holding the GIL. Single allocation, Rayon in-place random fill, hardware-accelerated CRC32 via `crc32fast`. ~5× faster than `numpy.savez()` for 140 MiB files (~20 ms vs ~178 ms). Returns a `BytesView` for zero-copy upload.
+> **`direct://` URIs now actually bypass the page cache:** `get_many(["direct:///path/file", ...])` was silently falling through to buffered `tokio::fs::read()` — O_DIRECT was never engaged. Fixed by routing `Scheme::Direct` through `ConfigurableFileSystemObjectStore::with_direct_io()`.
 >
-> **Zero-copy `BytesView` upload path:** `MultipartUploadWriter.write()` now detects `BytesView` objects first (path 0) via an Arc refcount increment — no `memcpy` at all. The GIL is released for the full duration of `write_bytes_blocking()`. For 140 MiB files this drops write latency from ~109 ms to ~6 ms and raises sustained upload throughput from ~1,250 MiB/s to ~2,440 MiB/s at N=48.
+> **BufferPool deadlock fix:** `BufferPool::give()` changed from async (`tx.send().await`) to sync (`tx.try_send()`). Prevents a race between the pre-allocation task and the caller's runtime that could deadlock when the channel is full.
 >
-> **`write_bytes_blocking(data: Bytes)`:** New zero-copy method on `MultipartUploadSink` — slices the shared `Arc<[u8]>` into part-sized chunks with `Bytes::slice()` (no copy), enqueues them to the coordinator channel, and copies only the final sub-part tail.
->
-> **v0.9.92 highlights also in this release:** Coordinator task + bounded channel MPU rewrite, auto-scale `max_in_flight`, async safety fixes. See [docs/Changelog.md](docs/Changelog.md) for full history.
+> **v0.9.94 also in this release:** Fast NPZ generation (`generate_npz_bytes()` — ~5× faster than `numpy.savez()`, GIL-free, Rayon parallel), zero-copy `BytesView` upload path (~2,440 MiB/s at N=48). See [docs/Changelog.md](docs/Changelog.md) for full history.
 
 ## 📦 Installation
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,31 @@
 # s3dlio Changelog
 
+## Version 0.9.95 — O_DIRECT fix, BufferPool deadlock fix (April 27, 2026)
+
+### Fix: `direct://` URIs now correctly use O_DIRECT in `get_many()` (`src/python_api/python_core_api.rs`)
+
+`Scheme::Direct` was previously handled by the same code branch as `Scheme::File`, causing `direct://` URIs to silently fall through to `tokio::fs::read()` — the standard buffered I/O path. Page-cache bypass was never actually engaged in `get_many()`.
+
+**Fix:** Split into two separate match arms. `Scheme::Direct` now creates a `ConfigurableFileSystemObjectStore::with_direct_io()` and submits all reads through it, bypassing the OS page cache as intended. `Scheme::File` retains its existing `tokio::fs::read()` path with the stale `direct://` prefix-stripping code removed.
+
+**Impact:** `direct://` reads in Python (`get_many(["direct:///path/file", ...])`) now actually bypass the page cache. This was a silent correctness bug — the API appeared to work but provided no O_DIRECT benefit.
+
+### Fix: `BufferPool::give()` deadlock (`src/memory.rs`, `src/file_store_direct.rs`)
+
+**Root cause:** `BufferPool::new(n, …)` spawns a pre-allocation task on the global background runtime that fills the channel to capacity `n`. If `take()` runs before pre-alloc completes (the normal case — the caller's runtime is usually faster), it allocates a new buffer via the fallback path, creating a `n+1`th buffer that the channel cannot hold. The previous `async fn give()` called `tx.send(buf).await`, which blocks indefinitely on a full channel with no concurrent drainer → **permanent deadlock**.
+
+This is a real production bug, not just a test issue. Any caller using `BufferPool` under high concurrency where `take()`'s fallback path fires (by design) could deadlock.
+
+**Fix:** `give()` changed from `async fn` using `tx.send().await` to a sync `fn` using `tx.try_send()`. If the channel is full, the buffer is simply dropped — correct behaviour, since fallback-allocated buffers are not needed by the pool. All call sites updated (`src/file_store_direct.rs`, `tests/test_buffer_pool_directio.rs`).
+
+**Test hardening:** `buffer_pool_basic` now wraps the test body in `tokio::time::timeout(5s)` so a regression will fail with a clear message instead of hanging indefinitely.
+
+### Internal: `global_rt_handle()` made `pub(crate)` (`src/s3_client.rs`)
+
+Allows `memory.rs` to spawn `BufferPool` pre-allocation tasks on the same background runtime used by all other async operations — consistent runtime behaviour across all URI schemes.
+
+---
+
 ## Version 0.9.94 — Fast NPZ generation, zero-copy BytesView upload path (April 25, 2026)
 
 ### New: `generate_npz_bytes()` — Rust NPZ builder (`src/data_formats/npz.rs`, `src/python_api/python_datagen_api.rs`)

--- a/docs/PYTHON_API_GUIDE.md
+++ b/docs/PYTHON_API_GUIDE.md
@@ -93,7 +93,7 @@ if s3dlio.exists("s3://my-bucket/data.bin"):
 | `gs://` | `gs://bucket/key` | Google Cloud Storage |
 | `az://` | `az://account/container/key` | Azure Blob Storage |
 | `file://` | `file:///path/to/file` | Local filesystem |
-| `direct://` | `direct:///path/to/file` | Direct I/O (O_DIRECT) |
+| `direct://` | `direct:///path/to/file` | Direct I/O (O_DIRECT) — bypasses the OS page cache. **v0.9.95:** correctly routed through `ConfigurableFileSystemObjectStore::with_direct_io()` in `get_many()` (previously silently used buffered I/O). |
 
 ---
 
@@ -306,7 +306,12 @@ results = s3dlio.get_many(uris, workers=64)
 
 # Async version
 results = await s3dlio.get_many_async(uris)
+
+# O_DIRECT reads — bypass page cache (v0.9.95: now correctly uses O_DIRECT)
+results = s3dlio.get_many(["direct:///data/file1.npz", "direct:///data/file2.npz"])
 ```
+
+> **v0.9.95 fix:** `direct://` URIs in `get_many()` previously fell through to the standard buffered `tokio::fs::read()` path — O_DIRECT was never engaged. Fixed in v0.9.95: `direct://` reads now go through `ConfigurableFileSystemObjectStore::with_direct_io()`, correctly bypassing the OS page cache.
 
 ### upload() / download() — Bulk File Transfer
 

--- a/docs/implementation-plans/v0.9.9-buffer-pool-enhancement.md
+++ b/docs/implementation-plans/v0.9.9-buffer-pool-enhancement.md
@@ -127,9 +127,9 @@ async fn try_read_range_direct(...) -> Result<Bytes> {
     let mut out = BytesMut::with_capacity(end - start);
     out.extend_from_slice(&aligned.as_slice()[start..end]);
     
-    // Return buffer to pool
+    // Return buffer to pool — give() is non-blocking (try_send), no .await
     if let Some(pool) = &self.config.buffer_pool {
-        pool.give(aligned).await;
+        pool.give(aligned);
     }
     
     Ok(out.freeze())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.9.94"
+version = "0.9.95"
 description = "High-performance Object Storage Library for Pytorch, Jax and Tensorflow: Object support inlcudes S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/file_store_direct.rs
+++ b/src/file_store_direct.rs
@@ -1111,8 +1111,11 @@ impl ConfigurableFileSystemObjectStore {
         let result = out.freeze();
 
         // Return aligned buffer to pool for reuse (v0.9.9+)
+        // give() is non-blocking (try_send): if the pool channel is full because
+        // a fallback-allocated buffer was used while the pre-alloc had already
+        // filled the channel, we simply drop the buffer rather than deadlocking.
         if let Some(pool) = &self.config.buffer_pool {
-            pool.give(aligned).await;
+            pool.give(aligned);
         }
 
         Ok(result)

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -8,6 +8,10 @@ use std::ptr::NonNull;
 use std::sync::Arc;
 use tokio::sync::{mpsc, Semaphore};
 
+// Import global runtime handle so BufferPool pre-allocation uses the same
+// dedicated s3dlio runtime as all other async operations (S3, file://, direct://).
+use crate::s3_client::global_rt_handle;
+
 /// Aligned memory buffer suitable for O_DIRECT I/O and zero-copy operations
 ///
 /// This buffer is allocated with specific alignment requirements (typically 4096 bytes)
@@ -116,9 +120,15 @@ impl BufferPool {
             align,
         });
 
-        // Pre-allocate all buffers
+        // Pre-allocate all buffers onto the global s3dlio Tokio runtime.
+        //
+        // Using global_rt_handle().spawn() (instead of tokio::spawn()) makes
+        // file:// and direct:// behave exactly like S3: all async work goes
+        // through the same dedicated background runtime regardless of URI scheme.
+        // This is safe to call from any thread context — the global runtime is
+        // always available once first accessed (lazy init via OnceLock).
         let pool_clone = pool.clone();
-        tokio::spawn(async move {
+        global_rt_handle().spawn(async move {
             for _ in 0..capacity {
                 let buf = AlignedBuf::new(buf_len, align);
                 if pool_clone.tx.send(buf).await.is_err() {
@@ -146,10 +156,14 @@ impl BufferPool {
     }
 
     /// Return a buffer to the pool for reuse
-    pub async fn give(&self, buf: AlignedBuf) {
+    ///
+    /// Uses `try_send` (non-blocking): if the pool channel is already at capacity
+    /// (e.g. because all pre-allocated buffers are present), the returned buffer is
+    /// simply dropped rather than blocking the caller forever.
+    pub fn give(&self, buf: AlignedBuf) {
         // Only return buffers with the correct size and alignment
         if buf.len() == self.buf_len && buf.align() == self.align {
-            let _ = self.tx.send(buf).await; // Ignore error if pool is full/closed
+            let _ = self.tx.try_send(buf); // Non-blocking: drop if pool is full
         }
         // If buffer doesn't match pool parameters, just drop it
     }
@@ -225,21 +239,31 @@ mod tests {
 
     #[tokio::test]
     async fn buffer_pool_basic() {
-        let pool = BufferPool::new(2, 4096, 4096);
+        // Timeout guard: this test must complete in under 5 seconds.
+        // A hang here means give() is blocking on a full channel (deadlock) —
+        // that is a real production bug, not just a test issue.
+        let result = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            let pool = BufferPool::new(2, 4096, 4096);
 
-        // Take buffer
-        let mut buf1 = pool.take().await;
-        assert_eq!(buf1.len(), 4096);
+            // Take buffer
+            let mut buf1 = pool.take().await;
+            assert_eq!(buf1.len(), 4096);
 
-        // Modify buffer
-        buf1.as_mut_slice()[0] = 123;
+            // Modify buffer
+            buf1.as_mut_slice()[0] = 123;
 
-        // Return buffer
-        pool.give(buf1).await;
+            // Return buffer (non-blocking try_send — must not deadlock even if pool is full)
+            pool.give(buf1);
 
-        // Take again - should get a buffer (possibly reused)
-        let buf2 = pool.take().await;
-        assert_eq!(buf2.len(), 4096);
+            // Take again - should get a buffer (possibly reused)
+            let buf2 = pool.take().await;
+            assert_eq!(buf2.len(), 4096);
+        })
+        .await;
+        assert!(
+            result.is_ok(),
+            "buffer_pool_basic timed out — give() deadlocked on full channel"
+        );
     }
 
     #[test]

--- a/src/python_api/python_core_api.rs
+++ b/src/python_api/python_core_api.rs
@@ -1269,9 +1269,43 @@ pub fn get_many(
                     .map(|(u, b)| (u, PyBytesView::new(b)))
                     .collect())
             }
-            Scheme::File | Scheme::Direct => {
-                // Parallel file reads
-                // Submit to global runtime (io_uring pattern — never calls block_on)
+            Scheme::Direct => {
+                // Parallel O_DIRECT reads — bypass page cache via ConfigurableFileSystemObjectStore
+                let uris_clone = uris.clone();
+                let res = submit_io(async move {
+                    let store = Arc::new(ConfigurableFileSystemObjectStore::with_direct_io());
+                    let sem = Arc::new(Semaphore::new(max_in_flight));
+                    let mut futs = FuturesUnordered::new();
+
+                    for uri in uris_clone.iter().cloned() {
+                        let store = Arc::clone(&store);
+                        let sem = Arc::clone(&sem);
+                        futs.push(tokio::spawn(async move {
+                            let _permit = sem.acquire_owned().await.unwrap();
+                            let bytes = store.get(&uri).await?;
+                            Ok::<_, anyhow::Error>((uri, bytes))
+                        }));
+                    }
+
+                    let mut out = Vec::new();
+                    while let Some(res) = futs.next().await {
+                        let (uri, bytes) =
+                            res.map_err(|e| anyhow::anyhow!("Task join error: {}", e))??;
+                        out.push((uri, bytes));
+                    }
+
+                    // Maintain input order
+                    out.sort_by_key(|(u, _)| uris_clone.iter().position(|x| x == u).unwrap());
+                    Ok::<_, anyhow::Error>(out)
+                })?;
+
+                Ok(res
+                    .into_iter()
+                    .map(|(u, b)| (u, PyBytesView::new(b)))
+                    .collect())
+            }
+            Scheme::File => {
+                // Parallel buffered file reads
                 let uris_clone = uris.clone();
                 let res = submit_io(async move {
                     let sem = Arc::new(Semaphore::new(max_in_flight));
@@ -1281,10 +1315,7 @@ pub fn get_many(
                         let sem = Arc::clone(&sem);
                         futs.push(tokio::spawn(async move {
                             let _permit = sem.acquire_owned().await.unwrap();
-                            let path = uri
-                                .strip_prefix("file://")
-                                .or_else(|| uri.strip_prefix("direct://"))
-                                .unwrap_or(&uri);
+                            let path = uri.strip_prefix("file://").unwrap_or(&uri);
                             let file_bytes = tokio::fs::read(path).await?;
                             Ok::<_, std::io::Error>((uri, Bytes::from(file_bytes)))
                         }));

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -63,7 +63,9 @@ pub fn configure_for_concurrency(n: usize) {
 }
 
 // Create (once) a background multi-thread Tokio runtime and return its Handle.
-fn global_rt_handle() -> &'static Handle {
+// pub(crate) so that other modules (e.g. memory.rs) can spawn onto the same
+// runtime, ensuring consistent async behaviour across all URI schemes.
+pub(crate) fn global_rt_handle() -> &'static Handle {
     RT_HANDLE.get_or_init(|| {
         let (tx, rx) = mpsc::sync_channel(1);
         thread::Builder::new()

--- a/tests/test_buffer_pool_directio.rs
+++ b/tests/test_buffer_pool_directio.rs
@@ -34,9 +34,9 @@ async fn test_buffer_pool_initialization() -> Result<()> {
     let buf2 = pool.take().await;
     assert_eq!(buf2.len(), 64 * 1024 * 1024, "Pool buffer should be 64MB");
 
-    // Return buffers
-    pool.give(buf1).await;
-    pool.give(buf2).await;
+    // Return buffers — give() is non-blocking (try_send), no .await needed
+    pool.give(buf1);
+    pool.give(buf2);
 
     // Take many buffers to verify pool can handle concurrent access
     let mut buffers = Vec::new();
@@ -51,9 +51,9 @@ async fn test_buffer_pool_initialization() -> Result<()> {
         buffers.push(buf.unwrap());
     }
 
-    // Return all buffers to pool for reuse
+    // Return all buffers to pool for reuse — give() is non-blocking (try_send)
     for buf in buffers {
-        pool.give(buf).await;
+        pool.give(buf);
     }
 
     println!("✅ Buffer pool initialization validated: semaphore-based capacity control with grow-on-demand");


### PR DESCRIPTION
# v0.9.95 — O_DIRECT fix, BufferPool deadlock fix

## Changes

### Fix: `direct://` URIs silently used buffered I/O in `get_many()`

`Scheme::Direct` was handled by the same match arm as `Scheme::File`, so
`get_many(["direct:///path/file", ...])` fell through to `tokio::fs::read()` —
O_DIRECT was never engaged. Split into separate arms; `Scheme::Direct` now
routes through `ConfigurableFileSystemObjectStore::with_direct_io()`.

### Fix: `BufferPool::give()` deadlock

`BufferPool::new(n, …)` pre-allocates buffers on the background runtime, filling
the channel to capacity `n`. If `take()` runs first (normal: caller's runtime
is faster), it allocates a fallback buffer — a `n+1`th buffer the channel cannot
hold. The old `async fn give()` called `tx.send(buf).await`, blocking forever on
a full channel with no drainer → permanent deadlock.

`give()` is now a sync `fn` using `tx.try_send()`. If the channel is full the
buffer is dropped — correct behaviour for a fallback-allocated buffer. All call
sites updated (`src/file_store_direct.rs`, `tests/test_buffer_pool_directio.rs`).
Test hardened with a 5 s `tokio::time::timeout`.

### Internal: `global_rt_handle()` made `pub(crate)`

Allows `memory.rs` to spawn `BufferPool` pre-alloc on the same shared background
runtime used by all other async operations.

## Test results

580 tests passing, 0 failures. `cargo clippy` clean, `cargo fmt` applied.
