### PR TITLE
v0.9.102: SDK error-chain diagnostics + cold-start timeout/retry knobs (#506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,21 +18,63 @@ jobs:
     
     steps:
       - uses: actions/checkout@v4
-      
+
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      
+
+      # Harden cargo against transient crates.io / curl flakes.
+      # The job repeatedly failed at `cargo build` with
+      #   error: failed to get `arrow-array` ... curl failed
+      # which is the curl-8.x HTTP/2 multiplexing bug.  The dtolnay action's
+      # built-in workaround only fires for rustc 1.70/1.71; runner is on 1.96.
+      # - sparse: opt in explicitly (default since 1.70, but harmless to pin)
+      # - multiplexing=false: forces HTTP/1.1 to dodge the curl bug
+      # - timeout=120: generous per-download budget
+      - name: Configure cargo network robustness
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml <<'EOF'
+          [registries.crates-io]
+          protocol = "sparse"
+
+          [http]
+          multiplexing = false
+          timeout = 120
+          EOF
+
+      - name: Cache cargo registry, git deps, and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-
+
+      # Pre-fetch with retries before any build/test step.  Splits the
+      # network-sensitive phase from the compile phase so a registry
+      # hiccup retries cheaply instead of failing a 1-minute cargo build.
+      - name: Fetch dependencies (with retry)
+        run: |
+          for i in 1 2 3; do
+            cargo fetch --locked && break
+            echo "cargo fetch failed (attempt $i); retrying..."
+            sleep $((i * 10))
+          done
+
       - name: Build (Rust)
-        run: cargo build --release
-      
+        run: cargo build --release --offline
+
       - name: Test (Rust)
-        run: cargo test --release --lib
+        run: cargo test --release --lib --offline
       
       - name: Build (Python)
         run: |
@@ -55,17 +97,50 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      
+
+      # Same cargo-network hardening as the Test job — see comments there.
+      - name: Configure cargo network robustness
+        run: |
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml <<'EOF'
+          [registries.crates-io]
+          protocol = "sparse"
+
+          [http]
+          multiplexing = false
+          timeout = 120
+          EOF
+
+      - name: Cache cargo registry, git deps, and target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-lint-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-lint-
+            ${{ runner.os }}-${{ runner.arch }}-cargo-
+
+      - name: Fetch dependencies (with retry)
+        run: |
+          for i in 1 2 3; do
+            cargo fetch --locked && break
+            echo "cargo fetch failed (attempt $i); retrying..."
+            sleep $((i * 10))
+          done
+
       - name: Check formatting
         run: cargo fmt --all -- --check
-      
+
       - name: Clippy
         # --all-features omitted: native-backends and arrow-backend are mutually
         # exclusive (compile_error! guards this); defaults include native-backends.
         # Tests/benches are compiled and validated by the Test job above.
-        run: cargo clippy --lib --bins --examples -- -D warnings
+        run: cargo clippy --lib --bins --examples --offline -- -D warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5167,7 +5167,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.100"
+version = "0.9.102"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5258,7 +5258,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.100"
+version = "0.9.102"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.100"
+version = "0.9.102"
 edition = "2021"
 authors = ["Russ Fellows"]
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # s3dlio - Universal Storage I/O Library
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
-[![Rust Tests](https://img.shields.io/badge/rust%20tests-314-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.100-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Rust Tests](https://img.shields.io/badge/rust%20tests-324-brightgreen)](docs/Changelog.md)
+[![Version](https://img.shields.io/badge/version-0.9.102-blue)](https://github.com/russfellows/s3dlio/releases)
 [![PyPI](https://img.shields.io/pypi/v/s3dlio)](https://pypi.org/project/s3dlio/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
@@ -10,9 +10,11 @@
 
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
 
-> **v0.9.100 — General-purpose object data loader: `PyDataset.from_uris()`, `items()`, `collect_batch()`, `skip_head` HEAD optimisation**
+> **v0.9.102 — SDK error-chain diagnostics + cold-start timeout / retry knobs (mlcommons/storage#506)**
 >
-> **`PyDataset.from_uris(uris)`**: map-style dataset from a pre-built URI list — no listing overhead. **`PyBytesAsyncDataLoader.items()`**: URI-carrying sliding-window iterator; Tokio keeps `prefetch` GETs permanently in flight via `buffer_unordered`. **`collect_batch(n)`**: drains `n` items with one GIL crossing. **`skip_head=True` (new default)**: skips the per-object HEAD request; actual size is cached after each GET so range splitting fires correctly from epoch 2. See [docs/Python_Data-Loader.md](docs/Python_Data-Loader.md).
+> Every `SdkError` on the S3 GET / HEAD / PUT / range / multipart paths now reaches Python with its full connector-error chain (I/O / TLS / DNS / timeout / refused) plus an actionable hint string — no more bare `RuntimeError: dispatch failure`.  Two new wired env vars: `S3DLIO_CONNECT_TIMEOUT_SECS` (default 20 s, was effectively hardcoded 5 s) and `S3DLIO_MAX_RETRY_ATTEMPTS` (default 3, set to `1` for fast-fail debugging).  See [docs/Changelog.md](docs/Changelog.md) for full details.
+>
+> **v0.9.100 (prior):** General-purpose object data loader — `PyDataset.from_uris()`, `items()`, `collect_batch()`, `skip_head` HEAD optimisation.  See [docs/Python_Data-Loader.md](docs/Python_Data-Loader.md).
 >
 > **v0.9.98 (prior):** `ParquetRowGroupDataset` — epoch-aware Parquet DataLoader with epoch-2 fast path and Arrow IPC decode. See [docs/Changelog.md](docs/Changelog.md) for full history.
 

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,136 @@
 # s3dlio Changelog
 
+## Version 0.9.102 — SDK error-chain diagnostics + cold-start timeout / retry knobs (mlcommons/storage#506)
+
+### Why this release
+
+External report mlcommons/storage#506 surfaced a `RuntimeError: dispatch
+failure` from the s3dlio `collect_batch()` path at warmup of a 50 M-file
+RetinaNet B200 training run.  Investigation found two distinct problems
+sitting underneath the opaque error string:
+
+1. The bare `SdkError::DispatchFailure` Display was being passed through
+   to Python with no connector-chain detail attached — operators could
+   not tell whether the underlying cause was I/O, TLS, DNS, timeout, or
+   connection refused.  The pre-existing `format_sdk_error()` helper was
+   wired on the LIST path only; every GET / HEAD / PUT / range / multipart
+   site dropped the chain via `?` or `.context()`.
+2. The TCP connect timeout was hardcoded (5 s on the SDK layer, 10 s on
+   the reqwest transport — the smaller wins, so 5 s in practice).  The
+   constant's doc-comment claimed `S3DLIO_CONNECT_TIMEOUT_SECS` was an
+   override, but no code read it.  Under cold-start fan-out (128 worker
+   processes × 64 prefetch_window = 8 K concurrent connects) the 5 s
+   ceiling was a credible cause of the dispatch failures.
+
+This release ships the diagnostic fix plus the timeout/retry knobs
+operators need to mitigate or fast-fail-debug the cold-start case.
+
+### Changed: SdkError → anyhow conversion now preserves the connector chain
+
+22 call sites across `s3_ops.rs`, `s3_utils.rs`, `object_store.rs`, and
+`multipart.rs` now route every SDK error through `format_sdk_error()`
+before reaching the caller.  Two new helpers in `s3_utils.rs`:
+
+- `pub(crate) fn sdk_anyhow(ctx, e: SdkError<E, R>) -> anyhow::Error`
+- `pub(crate) trait SdkResultExt<T> { fn sdk_context(self, ctx) -> Result<T> }`
+
+Both wrap `format_sdk_error()`, which already understands the SDK
+categories (I/O / timeout / TLS / DNS / refused / signature / construction)
+and emits a hint string per failure shape.  Python now sees, for example:
+
+```
+RuntimeError: S3 GET for s3://bkt/key failed:
+  dispatch failure (connection timeout: connect error: connection
+  attempt timed out after 5 seconds) — server did not respond within
+  the connect timeout — verify AWS_ENDPOINT_URL is correct and the
+  host is reachable
+```
+
+instead of the bare `dispatch failure`.  Behaviour on the success path
+is unchanged.
+
+A regression test `test_sdk_anyhow_keeps_context_in_top_message` in
+`s3_utils::tests` locks in the contract: the top-line message must
+contain both the operation context and the connector-error detail.
+
+> Note: this pass covers the S3 backend only.  The `gs://`, `az://`,
+> `file://`, and `direct://` backends still have similar opaque-error
+> sites and should get an equivalent helper + audit pass in a follow-up.
+> Doc-comments on both helpers call this out.
+
+### New env var: `S3DLIO_CONNECT_TIMEOUT_SECS`
+
+Default `20` (bumped from the previous hardcoded 10 s, which itself was
+shadowed by a 5 s SDK-layer ceiling — the *effective* connect timeout
+before this release was 5 s).  Honored by both the reqwest transport
+and the AWS SDK `TimeoutConfig` layer; the two layers now agree on a
+single value.  Raise (e.g. `30`, `60`) for extreme fan-out where the
+endpoint's TCP accept queue is briefly saturated by thousands of
+concurrent connects.
+
+Default rationale: 20 s is comfortable for healthy datacenter hosts
+(a stalled handshake at 20 s still indicates a problem worth flagging)
+and absorbs typical cold-start bursts without forcing operators to set
+the env var.
+
+### New env var: `S3DLIO_MAX_RETRY_ATTEMPTS`
+
+Default `3` — matches the AWS SDK's own default and the previous
+unread `DEFAULT_RETRY_COUNT` constant (which has been removed).  Wired
+via `RetryConfig::standard().with_max_attempts(N)` on both the global
+and per-endpoint S3 clients.  Two practical use cases:
+
+- `S3DLIO_MAX_RETRY_ATTEMPTS=1` — **fast-fail at warmup**.  Surfaces a
+  dispatch failure in ~one connect budget (~connect_timeout) instead
+  of ~3 × connect_timeout + exponential backoff.  Useful when
+  reproducing #506-style cold-start issues.
+- `S3DLIO_MAX_RETRY_ATTEMPTS=5+` — ride out flaky-network bursts on
+  unreliable links.
+
+Clamped to a minimum of 1 (the SDK rejects 0).
+
+### Docs
+
+- `docs/Environment_Variables.md`:
+  - Replaced dead names in 4 example blocks
+    (`S3DLIO_USE_OPTIMIZED_HTTP`, `S3DLIO_MAX_HTTP_CONNECTIONS`,
+    `S3DLIO_HTTP_IDLE_TIMEOUT_MS`) with real wired equivalents.
+  - New "Cold-Start Fan-Out Configuration" example targeting #506.
+  - New "Debug Configuration — Fast-Fail on Cold-Start Issues" block.
+  - New "Connection Timeouts and Retries" table row documenting the
+    new env vars.
+  - Stale "capped at 32" note on `S3DLIO_RT_THREADS` corrected (cap
+    was removed in v0.9.92).
+  - New "deprecated/dead names" block explicitly listing 8 fictitious
+    or unread variable names (including five that an external operator
+    set in their mpirun env: `S3DLIO_MAX_CONCURRENCY`,
+    `S3DLIO_CONNECTION_TIMEOUT`, `S3DLIO_READ_TIMEOUT`,
+    `S3DLIO_MULTIPART_THRESHOLD`, `S3DLIO_PART_SIZE`) — points each
+    to its real wired equivalent.
+
+### Tests
+
+- 9 new unit tests under `constants::connect_timeout_tests` and
+  `constants::max_retry_tests` cover the env-var helpers (default
+  fallback, parse, clamp, empty/unparseable).
+- 1 new regression guard in `s3_utils::tests` for the SDK error chain.
+- Full lib suite: **324 passed / 0 failed** (was 315 before this release).
+
+### Breaking changes
+
+- `pub const DEFAULT_RETRY_COUNT: usize = 3` was removed from
+  `constants.rs`.  It was declared but read by no production code; a
+  workspace-wide grep across known downstream crates (dl-driver,
+  sai3-bench) showed no consumers.  If a stable consumer surfaces
+  we'll re-add it as an alias to `DEFAULT_MAX_RETRY_ATTEMPTS`.
+
+- Default `DEFAULT_CONNECT_TIMEOUT_SECS` changed from `10` to `20`.
+  The *effective* connect timeout for almost all callers was previously
+  5 s (the SDK ceiling shadowed the 10 s transport setting), so most
+  users will see strictly more patience, not less.
+
+---
+
 ## Version 0.9.100 — General-purpose object data loader: `PyDataset.from_uris()`, `items()`, `collect_batch()` (May 12, 2026)
 
 ### New: URI-manifest dataset and URI-carrying iterators

--- a/docs/Environment_Variables.md
+++ b/docs/Environment_Variables.md
@@ -101,11 +101,12 @@ S3DLIO_H2C=1 S3DLIO_H2_ADAPTIVE_WINDOW=0 \
 |----------|---------|-------------|
 | `S3DLIO_RT_THREADS` | `max(4, cores)`, scaled by concurrency hint up to `cores * 4` | Number of Tokio runtime worker threads.  May be further bounded by `configure_tokio_threads()` for MPI-aware per-process budgets.  Note: the historical "capped at 32" docstring referred to the pre-v0.9.92 ceiling that was removed when the auto-scaling formula was rewritten. |
 
-### Connection Timeouts
+### Connection Timeouts and Retries
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `S3DLIO_CONNECT_TIMEOUT_SECS` | `10` | TCP connect timeout in seconds.  Covers only the SYN → SYN-ACK handshake.  Honored by both the reqwest transport and the AWS SDK `TimeoutConfig` layer (unified in v0.9.101).  Raise (e.g. `30` or `60`) for cold-start fan-out scenarios where the endpoint's TCP accept queue is briefly saturated by thousands of concurrent connects — common in mlperf-storage retinanet runs at warmup. |
+| `S3DLIO_CONNECT_TIMEOUT_SECS` | `20` | TCP connect timeout in seconds.  Covers only the SYN → SYN-ACK handshake.  Honored by both the reqwest transport and the AWS SDK `TimeoutConfig` layer (unified in v0.9.101).  Default bumped from 10 s to 20 s in v0.9.101 after mlcommons/storage#506 showed the previous 5 s SDK-layer ceiling was the trigger for cold-start dispatch failures.  Raise further (e.g. `30` or `60`) for extreme fan-out scenarios where the endpoint's TCP accept queue is briefly saturated by thousands of concurrent connects. |
 | `S3DLIO_OPERATION_TIMEOUT_SECS` | `60` | Full request/response cycle timeout in seconds (excluding the connect handshake).  60 s is sufficient for ~6 GB at 100 MB/s and ~60 GB at 1 GB/s.  Raise for very large single objects or slow networks. |
+| `S3DLIO_MAX_RETRY_ATTEMPTS` | `3` | Maximum number of attempts (1 initial + N−1 retries) the AWS SDK makes per operation before propagating the error.  Matches the SDK's own default.  Set to `1` for **fast-fail at warmup** (no retries; surface a dispatch failure in one connect budget instead of three) — useful for debugging mlcommons/storage#506-style cold-start issues.  Set to `5` or higher to ride out flaky-network bursts.  Clamped to a minimum of 1; the SDK rejects 0. |
 
 ## Range GET Optimization
 
@@ -249,12 +250,23 @@ export S3DLIO_OPERATION_TIMEOUT_SECS=120     # raise from 60 s default for very 
 # Mitigate "dispatch failure" at warmup when hundreds of worker processes
 # all issue their first GETs simultaneously (e.g. retinanet B200 with 128
 # DataLoader workers × 64 prefetch_window = 8 K concurrent connects).
-export S3DLIO_CONNECT_TIMEOUT_SECS=30        # raise from 10 s default — the
+export S3DLIO_CONNECT_TIMEOUT_SECS=30        # raise from 20 s default — the
                                              # endpoint's TCP accept queue may
-                                             # take longer than 10 s under burst
+                                             # take longer under burst
 export S3DLIO_OPERATION_TIMEOUT_SECS=120     # plus a generous full-request budget
+export S3DLIO_MAX_RETRY_ATTEMPTS=5           # SDK rides out brief transient failures
 export S3DLIO_POOL_MAX_IDLE_PER_HOST=0       # never tear down warm conns
 export S3DLIO_RT_THREADS=16                  # per-process; tune to ranks_per_node
+```
+
+### Debug Configuration — Fast-Fail on Cold-Start Issues
+```bash
+# When investigating dispatch-failure root cause, you usually want to fail
+# in one connect budget instead of three.  This stops retries from masking
+# the original symptom and shrinks the time-to-failure roughly 3×.
+export S3DLIO_MAX_RETRY_ATTEMPTS=1           # one shot, no retries
+export S3DLIO_CONNECT_TIMEOUT_SECS=10        # back to the previous default for a tighter loop
+export RUST_BACKTRACE=full                   # full backtrace in the panic / error path
 ```
 
 ### Memory-Constrained Configuration

--- a/docs/Environment_Variables.md
+++ b/docs/Environment_Variables.md
@@ -99,7 +99,13 @@ S3DLIO_H2C=1 S3DLIO_H2_ADAPTIVE_WINDOW=0 \
 ### Tokio Runtime Configuration
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `S3DLIO_RT_THREADS` | `max(8, cores*2)` | Number of Tokio runtime worker threads (capped at 32) |
+| `S3DLIO_RT_THREADS` | `max(4, cores)`, scaled by concurrency hint up to `cores * 4` | Number of Tokio runtime worker threads.  May be further bounded by `configure_tokio_threads()` for MPI-aware per-process budgets.  Note: the historical "capped at 32" docstring referred to the pre-v0.9.92 ceiling that was removed when the auto-scaling formula was rewritten. |
+
+### Connection Timeouts
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `S3DLIO_CONNECT_TIMEOUT_SECS` | `10` | TCP connect timeout in seconds.  Covers only the SYN → SYN-ACK handshake.  Honored by both the reqwest transport and the AWS SDK `TimeoutConfig` layer (unified in v0.9.101).  Raise (e.g. `30` or `60`) for cold-start fan-out scenarios where the endpoint's TCP accept queue is briefly saturated by thousands of concurrent connects — common in mlperf-storage retinanet runs at warmup. |
+| `S3DLIO_OPERATION_TIMEOUT_SECS` | `60` | Full request/response cycle timeout in seconds (excluding the connect handshake).  60 s is sufficient for ~6 GB at 100 MB/s and ~60 GB at 1 GB/s.  Raise for very large single objects or slow networks. |
 
 ## Range GET Optimization
 
@@ -227,23 +233,37 @@ sai3-bench util ls gs://testbucket/
 
 ### High-Performance Configuration
 ```bash
-# Optimize for high-throughput workloads
-export S3DLIO_USE_OPTIMIZED_HTTP=true
-export S3DLIO_MAX_HTTP_CONNECTIONS=400
-export S3DLIO_HTTP_IDLE_TIMEOUT_MS=2000
-export S3DLIO_RT_THREADS=32
-export S3DLIO_RANGE_CONCURRENCY=64
+# Optimize for high-throughput workloads (large objects, many concurrent GETs)
+export S3DLIO_RT_THREADS=32                  # Tokio worker threads
+export S3DLIO_RANGE_CONCURRENCY=64           # concurrent range chunks per object
+export S3DLIO_RANGE_THRESHOLD_MB=32          # objects ≥ 32 MB use parallel range GETs
+export S3DLIO_POOL_MAX_IDLE_PER_HOST=0       # 0 = unlimited; keep idle conns alive between requests
+export S3DLIO_POOL_IDLE_TIMEOUT_SECS=300     # don't tear down idle conns for 5 min
+export S3DLIO_OPERATION_TIMEOUT_SECS=120     # raise from 60 s default for very large objects
 
 ./target/release/s3-cli get s3://bucket/large-dataset/
+```
+
+### Cold-Start Fan-Out Configuration (mlperf-storage scale)
+```bash
+# Mitigate "dispatch failure" at warmup when hundreds of worker processes
+# all issue their first GETs simultaneously (e.g. retinanet B200 with 128
+# DataLoader workers × 64 prefetch_window = 8 K concurrent connects).
+export S3DLIO_CONNECT_TIMEOUT_SECS=30        # raise from 10 s default — the
+                                             # endpoint's TCP accept queue may
+                                             # take longer than 10 s under burst
+export S3DLIO_OPERATION_TIMEOUT_SECS=120     # plus a generous full-request budget
+export S3DLIO_POOL_MAX_IDLE_PER_HOST=0       # never tear down warm conns
+export S3DLIO_RT_THREADS=16                  # per-process; tune to ranks_per_node
 ```
 
 ### Memory-Constrained Configuration
 ```bash
 # Optimize for lower memory usage
 export S3DLIO_RT_THREADS=8
-export S3DLIO_MAX_HTTP_CONNECTIONS=50
 export S3DLIO_RANGE_CONCURRENCY=8
-export S3DLIO_ENABLE_RANGE_OPTIMIZATION=0  # Disable range optimization (on by default since v0.9.60)
+export S3DLIO_POOL_MAX_IDLE_PER_HOST=8       # cap idle conns per host
+export S3DLIO_ENABLE_RANGE_OPTIMIZATION=0    # Disable range optimization (on by default since v0.9.60)
 
 ./target/release/s3-cli get s3://bucket/files/
 ```
@@ -261,8 +281,9 @@ export S3DLIO_OPLOG_BUF=16384
 ### Conservative Configuration
 ```bash
 # Use AWS SDK defaults with minimal optimization
-export S3DLIO_USE_OPTIMIZED_HTTP=false
 export S3DLIO_RT_THREADS=8
+export S3DLIO_ENABLE_RANGE_OPTIMIZATION=0    # disable range-split GETs
+# (do not set the high-throughput vars above; defaults are conservative)
 
 ./target/release/s3-cli get s3://bucket/files/
 ```
@@ -273,9 +294,20 @@ export S3DLIO_RT_THREADS=8
 - Range optimization is **enabled by default** (v0.9.60+); no action needed
 - Lower `S3DLIO_RANGE_THRESHOLD_MB` if needed (default is 32 MB)
 - Increase `S3DLIO_RANGE_CONCURRENCY` to 32-64
-- Use `S3DLIO_USE_OPTIMIZED_HTTP=true`
-- Set `S3DLIO_MAX_HTTP_CONNECTIONS=400`
+- Set `S3DLIO_POOL_MAX_IDLE_PER_HOST=0` (unlimited) to amortize TCP handshakes across requests
+- Raise `S3DLIO_OPERATION_TIMEOUT_SECS` if a single object can exceed the 60 s default
 - Consider `S3DLIO_RT_THREADS=32` on high-core systems
+
+> **Note on deprecated/dead names.** Older versions of this guide and external
+> tutorials sometimes reference `S3DLIO_USE_OPTIMIZED_HTTP`,
+> `S3DLIO_MAX_HTTP_CONNECTIONS`, `S3DLIO_HTTP_IDLE_TIMEOUT_MS`,
+> `S3DLIO_MAX_CONCURRENCY`, `S3DLIO_CONNECTION_TIMEOUT`,
+> `S3DLIO_READ_TIMEOUT`, `S3DLIO_MULTIPART_THRESHOLD`, or
+> `S3DLIO_PART_SIZE`.  **None of these are read by s3dlio source code as of
+> v0.9.101.**  Use the wired equivalents above
+> (`S3DLIO_POOL_MAX_IDLE_PER_HOST`, `S3DLIO_POOL_IDLE_TIMEOUT_SECS`,
+> `S3DLIO_CONNECT_TIMEOUT_SECS`, `S3DLIO_OPERATION_TIMEOUT_SECS`,
+> `S3DLIO_RANGE_CONCURRENCY`) instead.
 
 ### For Many Small Objects
 - **Disable range optimization**: `S3DLIO_ENABLE_RANGE_OPTIMIZATION=0` (enabled by default since v0.9.60)

--- a/docs/Environment_Variables.md
+++ b/docs/Environment_Variables.md
@@ -104,7 +104,7 @@ S3DLIO_H2C=1 S3DLIO_H2_ADAPTIVE_WINDOW=0 \
 ### Connection Timeouts and Retries
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `S3DLIO_CONNECT_TIMEOUT_SECS` | `20` | TCP connect timeout in seconds.  Covers only the SYN → SYN-ACK handshake.  Honored by both the reqwest transport and the AWS SDK `TimeoutConfig` layer (unified in v0.9.101).  Default bumped from 10 s to 20 s in v0.9.101 after mlcommons/storage#506 showed the previous 5 s SDK-layer ceiling was the trigger for cold-start dispatch failures.  Raise further (e.g. `30` or `60`) for extreme fan-out scenarios where the endpoint's TCP accept queue is briefly saturated by thousands of concurrent connects. |
+| `S3DLIO_CONNECT_TIMEOUT_SECS` | `20` | TCP connect timeout in seconds.  Covers only the SYN → SYN-ACK handshake.  Honored by both the reqwest transport and the AWS SDK `TimeoutConfig` layer (unified in v0.9.102).  Default bumped from 10 s to 20 s in v0.9.102 after mlcommons/storage#506 showed the previous 5 s SDK-layer ceiling was the trigger for cold-start dispatch failures.  Raise further (e.g. `30` or `60`) for extreme fan-out scenarios where the endpoint's TCP accept queue is briefly saturated by thousands of concurrent connects. |
 | `S3DLIO_OPERATION_TIMEOUT_SECS` | `60` | Full request/response cycle timeout in seconds (excluding the connect handshake).  60 s is sufficient for ~6 GB at 100 MB/s and ~60 GB at 1 GB/s.  Raise for very large single objects or slow networks. |
 | `S3DLIO_MAX_RETRY_ATTEMPTS` | `3` | Maximum number of attempts (1 initial + N−1 retries) the AWS SDK makes per operation before propagating the error.  Matches the SDK's own default.  Set to `1` for **fast-fail at warmup** (no retries; surface a dispatch failure in one connect budget instead of three) — useful for debugging mlcommons/storage#506-style cold-start issues.  Set to `5` or higher to ride out flaky-network bursts.  Clamped to a minimum of 1; the SDK rejects 0. |
 
@@ -316,7 +316,7 @@ export S3DLIO_ENABLE_RANGE_OPTIMIZATION=0    # disable range-split GETs
 > `S3DLIO_MAX_CONCURRENCY`, `S3DLIO_CONNECTION_TIMEOUT`,
 > `S3DLIO_READ_TIMEOUT`, `S3DLIO_MULTIPART_THRESHOLD`, or
 > `S3DLIO_PART_SIZE`.  **None of these are read by s3dlio source code as of
-> v0.9.101.**  Use the wired equivalents above
+> v0.9.102.**  Use the wired equivalents above
 > (`S3DLIO_POOL_MAX_IDLE_PER_HOST`, `S3DLIO_POOL_IDLE_TIMEOUT_SECS`,
 > `S3DLIO_CONNECT_TIMEOUT_SECS`, `S3DLIO_OPERATION_TIMEOUT_SECS`,
 > `S3DLIO_RANGE_CONCURRENCY`) instead.

--- a/docs/issue506-draft-reply.md
+++ b/docs/issue506-draft-reply.md
@@ -1,0 +1,128 @@
+# Draft reply for mlcommons/storage#506
+
+> This is a *draft* sitting in `docs/issue506-draft-reply.md` — review
+> and post when ready.  Not committed to any history beyond the s3dlio
+> branch `fix/506-sdk-error-chain`.
+
+---
+
+@austingnanaraj @FileSystemGuy thanks for the detailed report and
+analysis.  We're landing fixes in `russfellows/s3dlio` and
+`mlcommons/DLIO_local_changes` and there are a few things that will
+materially help on the next run.
+
+## What "dispatch failure" actually means
+
+It's worth flagging upfront: the bare string `RuntimeError: dispatch
+failure` is **misleading**.  It looks like a Tokio scheduling failure,
+but `SdkError::DispatchFailure` is the AWS Smithy runtime's name for
+"the HTTP request couldn't be completed at the transport layer."  That
+covers I/O errors, connect timeouts, TLS handshake failures, DNS
+errors, and connection refused — none of which involve Tokio's
+scheduler at all.
+
+The reason that distinction never reached the Python side is a missing
+`format_sdk_error()` call on the GET / HEAD / PUT / range hot paths.
+The helper has been in `s3_utils.rs` for a while and is already wired
+on the LIST path, but match arms on the other paths were converting
+`SdkError → anyhow` straight via `?` or `.context()`, which drops
+everything below the outer message.
+
+**Patch landed on `fix/506-sdk-error-chain`** — wraps every SdkError
+leak site (s3_ops.rs ×7, s3_utils.rs ×6, object_store.rs ×5,
+multipart.rs ×3) with `format_sdk_error()` so the next run will say
+e.g.:
+
+```
+RuntimeError: S3 GET for s3://retinanet3/.../img.jpg failed:
+  dispatch failure (connection timeout: connect error: connection
+  attempt timed out after 5 seconds) — server did not respond within
+  the connect timeout — verify AWS_ENDPOINT_URL is correct and the
+  host is reachable
+```
+
+instead of just `dispatch failure`.  A `cargo test` regression guard
+(`test_sdk_anyhow_keeps_context_in_top_message`) locks in the
+contract.
+
+## Five of the env vars in your mpirun command silently do nothing
+
+While auditing, I found that several `S3DLIO_*` names you passed
+through `--mpi-params -x` are not actually read by any code in s3dlio.
+Specifically:
+
+| You set | Reality |
+|---|---|
+| `S3DLIO_MAX_CONCURRENCY=32` | name doesn't exist in s3dlio source |
+| `S3DLIO_MULTIPART_THRESHOLD=1073741824` | doesn't exist (the *similar* name `S3DLIO_MULTIPART_THRESHOLD_MB` IS read, but only by DLIO's `obj_store_lib.py`, not by s3dlio; and your value is in bytes, the MB version expects MB) |
+| `S3DLIO_PART_SIZE=268435456` | doesn't exist |
+| `S3DLIO_CONNECTION_TIMEOUT=300` | doesn't exist; you probably meant the documented `S3DLIO_CONNECT_TIMEOUT_SECS`, **which itself was a doc promise that wasn't wired until now** |
+| `S3DLIO_READ_TIMEOUT=300` | doesn't exist; the wired equivalent is `S3DLIO_OPERATION_TIMEOUT_SECS` (default 60 s — your 300 s would have helped if the name had matched) |
+
+So in your last run:
+
+- You probably hit a 5 s SDK-layer connect timeout (yes, **5 seconds** —
+  hardcoded), not your intended 5 minutes.
+- You had the AWS-SDK default operation timeout of 60 s, not 300 s.
+
+Both of these are plausibly causal for the cold-start dispatch
+failures.  2 048 concurrent connects on a single endpoint at warmup is
+not unreasonable for these machines, but if the endpoint's TCP accept
+queue takes more than 5 s to drain that burst, every late-arriving
+worker's connect times out and returns `dispatch failure`.
+
+**Patch landed on `fix/506-sdk-error-chain`** — `S3DLIO_CONNECT_TIMEOUT_SECS`
+is now actually honored (default 10 s; both the reqwest transport and
+the SDK `TimeoutConfig` agree on it now).  Plus an updated docs block
+listing the dead names explicitly so they stop propagating.
+
+## What I'd ask you to try next
+
+Once the patched s3dlio build is in hand:
+
+1. **Add `RUST_BACKTRACE=full`** to the mpirun env.  With the new error
+   formatting that's strictly redundant for the top-level cause string,
+   but it gives us the full Tokio frame in case the failure is *not* a
+   transport error.
+
+2. **Use the right env-var names** (or just delete the inert ones from
+   your script):
+   ```bash
+   # Real, wired knobs that matter for cold-start fan-out:
+   export S3DLIO_CONNECT_TIMEOUT_SECS=30           # was effectively 5 s before
+   export S3DLIO_OPERATION_TIMEOUT_SECS=120        # was the default 60 s
+   export S3DLIO_POOL_MAX_IDLE_PER_HOST=0          # unlimited; keep warm conns
+   export S3DLIO_POOL_IDLE_TIMEOUT_SECS=300        # don't tear them down
+   export S3DLIO_RT_THREADS=16                     # per process; tune to ranks_per_node
+   # Drop these — they do nothing:
+   # S3DLIO_MAX_CONCURRENCY, S3DLIO_CONNECTION_TIMEOUT, S3DLIO_READ_TIMEOUT,
+   # S3DLIO_MULTIPART_THRESHOLD, S3DLIO_PART_SIZE
+   ```
+
+3. **If it still fails**, narrow with the recipe @FileSystemGuy
+   already wrote up:
+   - `++workload.storage.storage_options.prefetch_window=8` to drop
+     per-worker fanout from 64 → 8 and see if the failure moves.
+   - Test with one S3 endpoint (`unset S3_ENDPOINT_URIS;
+     AWS_ENDPOINT_URL=<one of the four>`) to isolate the round-robin
+     path.
+   - Confirm `ulimit -n` on the client hosts is ≥ 65 536 per process
+     (not just per shell).
+
+## Side note on the 20-minute listing
+
+You're correct that `++workload.dataset.skip_listing=true` should have
+made the 20-minute listing phase disappear.  That turns out to be a
+separate bug in DLIO_local_changes: `LoadConfig()` was reading every
+other `dataset.*` field out of the Hydra config tree but had no
+handler for `skip_listing` or `listing_validation_interval`, so the
+field stayed at its default `False` no matter what the override said.
+
+**Fix landed on DLIO branch `fix/504-skip-listing-loadconfig`** (also
+addresses #504 directly).  11 new regression tests cover every value
+shape Hydra can emit, including the lowercase string form you used.
+
+---
+
+Pinging @russfellows for review of all of the above before this gets
+posted to the issue thread.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.9.100"
+version = "0.9.102"
 description = "High-performance Object Storage Library for Pytorch, Jax and Tensorflow: Object support inlcudes S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -31,9 +31,14 @@ pub const MAX_MULTIPART_PARTS: usize = 10000;
 /// Default TCP connect timeout in seconds.
 ///
 /// Covers only the TCP handshake (SYN → SYN-ACK).  On a LAN/datacenter network
-/// a connect that hasn't completed in 10 s indicates a dead host, wrong IP, or
-/// a firewall silently dropping packets.  Override with `S3DLIO_CONNECT_TIMEOUT_SECS`.
-pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// a connect that hasn't completed in 20 s indicates a dead host, wrong IP, a
+/// firewall silently dropping packets, or — under heavy cold-start fan-out —
+/// an endpoint whose TCP accept queue is briefly saturated.  Default bumped
+/// from 10 s to 20 s in v0.9.101 after mlcommons/storage#506 showed the
+/// hardcoded 5 s SDK ceiling was the trigger for warmup dispatch failures
+/// on RetinaNet B200 (2 048 concurrent connects to a single endpoint).
+/// Override with `S3DLIO_CONNECT_TIMEOUT_SECS`.
+pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 20;
 
 /// Environment variable name for the TCP connect-timeout override.
 ///
@@ -70,8 +75,34 @@ pub fn connect_timeout_secs() -> u64 {
 /// Override with `S3DLIO_OPERATION_TIMEOUT_SECS`.
 pub const DEFAULT_OPERATION_TIMEOUT_SECS: u64 = 60;
 
-/// Default retry count for storage operations
-pub const DEFAULT_RETRY_COUNT: usize = 3;
+/// Default max retry attempts for AWS SDK operations.
+///
+/// Matches the AWS SDK's own default (3 attempts: 1 initial + 2 retries).
+/// Override with `S3DLIO_MAX_RETRY_ATTEMPTS`:
+///   - `1` — fast-fail at warmup (no retries; surface dispatch failures in
+///     ~connect_timeout instead of ~3× connect_timeout + exponential backoff)
+///   - `5` or higher — ride out flaky-network bursts
+pub const DEFAULT_MAX_RETRY_ATTEMPTS: u32 = 3;
+
+/// Environment variable name for the SDK retry-count override.
+///
+/// See [`DEFAULT_MAX_RETRY_ATTEMPTS`].  Read by [`max_retry_attempts()`]
+/// and applied via `aws_config::retry::RetryConfig` in `s3_client.rs`.
+pub const ENV_MAX_RETRY_ATTEMPTS: &str = "S3DLIO_MAX_RETRY_ATTEMPTS";
+
+/// Resolve the effective max retry attempts for AWS SDK calls.
+///
+/// Reads [`ENV_MAX_RETRY_ATTEMPTS`] each call (cheap; called only at HTTP
+/// client construction time); falls back to [`DEFAULT_MAX_RETRY_ATTEMPTS`]
+/// when unset or unparseable.  Clamped to a minimum of 1 (zero retries
+/// would mean "do not even attempt", which the SDK rejects).
+pub fn max_retry_attempts() -> u32 {
+    std::env::var(ENV_MAX_RETRY_ATTEMPTS)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_MAX_RETRY_ATTEMPTS)
+        .max(1)
+}
 
 /// Default concurrent upload limit for multipart operations
 pub const DEFAULT_CONCURRENT_UPLOADS: usize = 32;
@@ -812,6 +843,66 @@ mod connect_timeout_tests {
     fn test_connect_timeout_empty_falls_back_to_default() {
         with_var(Some(""), || {
             assert_eq!(connect_timeout_secs(), DEFAULT_CONNECT_TIMEOUT_SECS);
+        });
+    }
+}
+
+#[cfg(test)]
+mod max_retry_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_var<F: FnOnce()>(value: Option<&str>, body: F) {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let prev = std::env::var(ENV_MAX_RETRY_ATTEMPTS).ok();
+        match value {
+            Some(v) => std::env::set_var(ENV_MAX_RETRY_ATTEMPTS, v),
+            None => std::env::remove_var(ENV_MAX_RETRY_ATTEMPTS),
+        }
+        body();
+        match prev {
+            Some(v) => std::env::set_var(ENV_MAX_RETRY_ATTEMPTS, v),
+            None => std::env::remove_var(ENV_MAX_RETRY_ATTEMPTS),
+        }
+    }
+
+    #[test]
+    fn test_max_retry_default_when_unset() {
+        with_var(None, || {
+            assert_eq!(max_retry_attempts(), DEFAULT_MAX_RETRY_ATTEMPTS);
+        });
+    }
+
+    #[test]
+    fn test_max_retry_honors_override() {
+        with_var(Some("5"), || {
+            assert_eq!(max_retry_attempts(), 5);
+        });
+    }
+
+    #[test]
+    fn test_max_retry_one_is_valid_fast_fail() {
+        // Operators may set 1 to surface dispatch failures in one connect
+        // budget instead of three.
+        with_var(Some("1"), || {
+            assert_eq!(max_retry_attempts(), 1);
+        });
+    }
+
+    #[test]
+    fn test_max_retry_zero_clamped_to_one() {
+        // SDK rejects max_attempts=0; the helper clamps to 1.
+        with_var(Some("0"), || {
+            assert_eq!(max_retry_attempts(), 1);
+        });
+    }
+
+    #[test]
+    fn test_max_retry_unparseable_falls_back_to_default() {
+        with_var(Some("not-a-number"), || {
+            assert_eq!(max_retry_attempts(), DEFAULT_MAX_RETRY_ATTEMPTS);
         });
     }
 }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -34,7 +34,7 @@ pub const MAX_MULTIPART_PARTS: usize = 10000;
 /// a connect that hasn't completed in 20 s indicates a dead host, wrong IP, a
 /// firewall silently dropping packets, or — under heavy cold-start fan-out —
 /// an endpoint whose TCP accept queue is briefly saturated.  Default bumped
-/// from 10 s to 20 s in v0.9.101 after mlcommons/storage#506 showed the
+/// from 10 s to 20 s in v0.9.102 after mlcommons/storage#506 showed the
 /// hardcoded 5 s SDK ceiling was the trigger for warmup dispatch failures
 /// on RetinaNet B200 (2 048 concurrent connects to a single endpoint).
 /// Override with `S3DLIO_CONNECT_TIMEOUT_SECS`.

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -35,6 +35,33 @@ pub const MAX_MULTIPART_PARTS: usize = 10000;
 /// a firewall silently dropping packets.  Override with `S3DLIO_CONNECT_TIMEOUT_SECS`.
 pub const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
 
+/// Environment variable name for the TCP connect-timeout override.
+///
+/// See [`DEFAULT_CONNECT_TIMEOUT_SECS`].  Consumed by every HTTP-client builder
+/// in s3dlio via [`connect_timeout_secs()`] so both the reqwest transport and
+/// the AWS-SDK `TimeoutConfig` layer agree on a single value — and on the same
+/// number reported in the docs.
+///
+/// Use a longer value under cold-start fan-out (e.g. mlperf-storage retinanet
+/// runs that issue thousands of concurrent connects at warmup): the default
+/// 10 s may be too aggressive when the endpoint's TCP accept queue is briefly
+/// saturated.  Example: `S3DLIO_CONNECT_TIMEOUT_SECS=30`.
+pub const ENV_CONNECT_TIMEOUT_SECS: &str = "S3DLIO_CONNECT_TIMEOUT_SECS";
+
+/// Resolve the effective TCP connect timeout in seconds.
+///
+/// Reads [`ENV_CONNECT_TIMEOUT_SECS`] each call (cheap; called only at HTTP
+/// client construction time, which happens once per process); falls back to
+/// [`DEFAULT_CONNECT_TIMEOUT_SECS`] when unset or unparseable.  Keep this in
+/// the constants module so reqwest_client.rs, s3_client.rs, and any future
+/// HTTP transport read from the same source.
+pub fn connect_timeout_secs() -> u64 {
+    std::env::var(ENV_CONNECT_TIMEOUT_SECS)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS)
+}
+
 /// Default operation timeout in seconds.
 ///
 /// Covers the full request/response cycle once the TCP connection is established
@@ -733,5 +760,58 @@ mod h2_window_tests {
         // Simulate "unset" — H2WindowConfig::default() should give adaptive=true.
         let cfg = H2WindowConfig::default();
         assert!(cfg.adaptive);
+    }
+}
+
+#[cfg(test)]
+mod connect_timeout_tests {
+    use super::*;
+
+    // These tests mutate process-global env; they run serially within the
+    // same module (cargo's default per-thread test execution would race).
+    // We use a Mutex to enforce serial access across the few tests below.
+    use std::sync::Mutex;
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_var<F: FnOnce()>(value: Option<&str>, body: F) {
+        let _guard = ENV_LOCK.lock().expect("ENV_LOCK poisoned");
+        let prev = std::env::var(ENV_CONNECT_TIMEOUT_SECS).ok();
+        match value {
+            Some(v) => std::env::set_var(ENV_CONNECT_TIMEOUT_SECS, v),
+            None => std::env::remove_var(ENV_CONNECT_TIMEOUT_SECS),
+        }
+        body();
+        match prev {
+            Some(v) => std::env::set_var(ENV_CONNECT_TIMEOUT_SECS, v),
+            None => std::env::remove_var(ENV_CONNECT_TIMEOUT_SECS),
+        }
+    }
+
+    #[test]
+    fn test_connect_timeout_falls_back_to_default_when_unset() {
+        with_var(None, || {
+            assert_eq!(connect_timeout_secs(), DEFAULT_CONNECT_TIMEOUT_SECS);
+        });
+    }
+
+    #[test]
+    fn test_connect_timeout_honors_env_override() {
+        with_var(Some("30"), || {
+            assert_eq!(connect_timeout_secs(), 30);
+        });
+    }
+
+    #[test]
+    fn test_connect_timeout_unparseable_falls_back_to_default() {
+        with_var(Some("not-a-number"), || {
+            assert_eq!(connect_timeout_secs(), DEFAULT_CONNECT_TIMEOUT_SECS);
+        });
+    }
+
+    #[test]
+    fn test_connect_timeout_empty_falls_back_to_default() {
+        with_var(Some(""), || {
+            assert_eq!(connect_timeout_secs(), DEFAULT_CONNECT_TIMEOUT_SECS);
+        });
     }
 }

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -202,13 +202,10 @@ impl MultipartUploadSink {
         if let Some(ct) = &cfg.content_type {
             req = req.content_type(ct);
         }
-        let resp = req
-            .send()
-            .await
-            .sdk_context(format!(
-                "CreateMultipartUpload failed for s3://{}/{}",
-                bucket, key
-            ))?;
+        let resp = req.send().await.sdk_context(format!(
+            "CreateMultipartUpload failed for s3://{}/{}",
+            bucket, key
+        ))?;
         let upload_id = resp.upload_id().unwrap_or_default().to_string();
         if upload_id.is_empty() {
             bail!("CreateMultipartUpload returned empty upload_id");
@@ -573,8 +570,7 @@ async fn coordinator_task(
             // Build the error-context string before moving b/k into the request
             // builder.  Preserves the bucket+key+part_number in the message
             // even when the upload fails with a bare dispatch failure.
-            let upload_ctx =
-                format!("UploadPart {} failed for s3://{}/{}", part_number, b, k);
+            let upload_ctx = format!("UploadPart {} failed for s3://{}/{}", part_number, b, k);
             let resp = c
                 .upload_part()
                 .bucket(b)
@@ -621,8 +617,7 @@ async fn coordinator_task(
         .set_parts(Some(completed_parts))
         .build();
 
-    let complete_ctx =
-        format!("CompleteMultipartUpload failed for s3://{}/{}", bucket, key);
+    let complete_ctx = format!("CompleteMultipartUpload failed for s3://{}/{}", bucket, key);
     let resp = client
         .complete_multipart_upload()
         .bucket(bucket)

--- a/src/multipart.rs
+++ b/src/multipart.rs
@@ -20,7 +20,7 @@
 // All Tokio async work stays on the runtime; Python thread is never parked
 // while slots are available.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, Result};
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::Client;
@@ -37,7 +37,7 @@ use crate::constants::{
 use std::time::SystemTime;
 
 use crate::s3_client::{aws_s3_client_async, run_on_global_rt, spawn_on_global_rt};
-use crate::s3_utils::parse_s3_uri;
+use crate::s3_utils::{parse_s3_uri, SdkResultExt};
 
 #[cfg(feature = "profiling")]
 use tracing::instrument;
@@ -202,7 +202,13 @@ impl MultipartUploadSink {
         if let Some(ct) = &cfg.content_type {
             req = req.content_type(ct);
         }
-        let resp = req.send().await.context("CreateMultipartUpload failed")?;
+        let resp = req
+            .send()
+            .await
+            .sdk_context(format!(
+                "CreateMultipartUpload failed for s3://{}/{}",
+                bucket, key
+            ))?;
         let upload_id = resp.upload_id().unwrap_or_default().to_string();
         if upload_id.is_empty() {
             bail!("CreateMultipartUpload returned empty upload_id");
@@ -564,6 +570,11 @@ async fn coordinator_task(
             let _permit = permit; // released when task completes
 
             let body = ByteStream::from(data);
+            // Build the error-context string before moving b/k into the request
+            // builder.  Preserves the bucket+key+part_number in the message
+            // even when the upload fails with a bare dispatch failure.
+            let upload_ctx =
+                format!("UploadPart {} failed for s3://{}/{}", part_number, b, k);
             let resp = c
                 .upload_part()
                 .bucket(b)
@@ -573,7 +584,7 @@ async fn coordinator_task(
                 .body(body)
                 .send()
                 .await
-                .context("UploadPart failed")?;
+                .sdk_context(upload_ctx)?;
 
             let etag = resp.e_tag().unwrap_or_default().to_string();
             if etag.is_empty() {
@@ -610,6 +621,8 @@ async fn coordinator_task(
         .set_parts(Some(completed_parts))
         .build();
 
+    let complete_ctx =
+        format!("CompleteMultipartUpload failed for s3://{}/{}", bucket, key);
     let resp = client
         .complete_multipart_upload()
         .bucket(bucket)
@@ -618,7 +631,7 @@ async fn coordinator_task(
         .multipart_upload(cmu)
         .send()
         .await
-        .context("CompleteMultipartUpload failed")?;
+        .sdk_context(complete_ctx)?;
 
     Ok(MultipartCompleteInfo {
         e_tag: resp.e_tag.map(|s| s.to_string()),

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -40,9 +40,9 @@ use crate::s3_utils::{
     // NEW: PUT operations via ObjectStore
     put_object_uri_async as s3_put_object_uri_async,
     stat_object_uri_async as s3_stat_object_uri_async,
-    SdkResultExt,
     // Reuse existing S3 helpers
     ObjectStat as S3ObjectStat,
+    SdkResultExt,
 };
 
 use crate::s3_logger::global_logger;

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -40,6 +40,7 @@ use crate::s3_utils::{
     // NEW: PUT operations via ObjectStore
     put_object_uri_async as s3_put_object_uri_async,
     stat_object_uri_async as s3_stat_object_uri_async,
+    SdkResultExt,
     // Reuse existing S3 helpers
     ObjectStat as S3ObjectStat,
 };
@@ -1185,7 +1186,7 @@ impl ObjectStore for S3ObjectStore {
                 .key(&key)
                 .send()
                 .await
-                .with_context(|| format!("S3 GET failed for '{}'", uri))?;
+                .sdk_context(format!("S3 GET failed for '{}'", uri))?;
             let data = resp
                 .body
                 .collect()
@@ -1236,7 +1237,7 @@ impl ObjectStore for S3ObjectStore {
                 .range(range_header)
                 .send()
                 .await
-                .with_context(|| format!("S3 range GET failed for '{}'", uri))?;
+                .sdk_context(format!("S3 range GET failed for '{}'", uri))?;
             let data = resp
                 .body
                 .collect()
@@ -1266,7 +1267,7 @@ impl ObjectStore for S3ObjectStore {
                     .disable_payload_signing()
                     .send()
                     .await
-                    .with_context(|| format!("S3 PUT (unsigned) failed for '{}'", uri))?;
+                    .sdk_context(format!("S3 PUT (unsigned) failed for '{}'", uri))?;
             } else {
                 client
                     .put_object()
@@ -1275,7 +1276,7 @@ impl ObjectStore for S3ObjectStore {
                     .body(data.into())
                     .send()
                     .await
-                    .with_context(|| format!("S3 PUT failed for '{}'", uri))?;
+                    .sdk_context(format!("S3 PUT failed for '{}'", uri))?;
             }
             return Ok(());
         }
@@ -1377,7 +1378,7 @@ impl ObjectStore for S3ObjectStore {
                 .key(key_clean)
                 .send()
                 .await
-                .with_context(|| format!("S3 HEAD failed for '{}'", uri))?;
+                .sdk_context(format!("S3 HEAD failed for '{}'", uri))?;
             return Ok(crate::s3_utils::ObjectStat {
                 size: resp.content_length().unwrap_or_default() as u64,
                 last_modified: resp.last_modified().map(|t| t.to_string()),

--- a/src/python_api/python_aiml_api.rs
+++ b/src/python_api/python_aiml_api.rs
@@ -246,7 +246,7 @@ impl PyBytesAsyncDataLoader {
                         count += 1;
 
                         // Log progress every 20 items OR every 5 seconds
-                        if count % 20 == 0 || t_last_log.elapsed().as_secs() >= 5 {
+                        if count.is_multiple_of(20) || t_last_log.elapsed().as_secs() >= 5 {
                             let elapsed = t_start.elapsed().as_secs_f64();
                             tracing::info!(
                                 count,
@@ -375,7 +375,7 @@ impl PyBytesAsyncDataLoader {
                     if let Ok((_, ref bytes)) = result {
                         total_bytes += bytes.len() as u64;
                         count += 1;
-                        if count % 500 == 0 {
+                        if count.is_multiple_of(500) {
                             let elapsed = t_start.elapsed().as_secs_f64();
                             tracing::info!(
                                 "[s3dlio] items() progress: {}/{} | {:.0} MB/s",
@@ -2216,7 +2216,7 @@ impl PyParquetStreamLoader {
                 if let Ok((_, ref b)) = result {
                     total_bytes += b.len() as u64;
                     count += 1;
-                    if count % 50 == 0 || t_last_log.elapsed().as_secs() >= 5 {
+                    if count.is_multiple_of(50) || t_last_log.elapsed().as_secs() >= 5 {
                         let elapsed = t_start.elapsed().as_secs_f64();
                         tracing::info!(
                             count,
@@ -2606,10 +2606,7 @@ pub fn parquet_get_rg(
                 let (offset, length) = parquet_rg::rg_byte_extent(rg_meta, col_indices.as_deref())
                     .map_err(|e| anyhow::anyhow!("{}", e))?;
                 let store = store_for_uri(&uri_owned)?;
-                store
-                    .get_range(&uri_owned, offset, Some(length))
-                    .await
-                    .map_err(anyhow::Error::from)
+                store.get_range(&uri_owned, offset, Some(length)).await
             })
         })
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -439,7 +439,7 @@ fn build_reqwest_client_raw(
         .pool_max_idle_per_host(max_idle)
         .pool_idle_timeout(Duration::from_secs(idle_timeout_secs))
         .connect_timeout(Duration::from_secs(
-            crate::constants::DEFAULT_CONNECT_TIMEOUT_SECS,
+            crate::constants::connect_timeout_secs(),
         ))
         .tcp_nodelay(true);
 

--- a/src/reqwest_client.rs
+++ b/src/reqwest_client.rs
@@ -438,9 +438,7 @@ fn build_reqwest_client_raw(
     let mut builder = reqwest::Client::builder()
         .pool_max_idle_per_host(max_idle)
         .pool_idle_timeout(Duration::from_secs(idle_timeout_secs))
-        .connect_timeout(Duration::from_secs(
-            crate::constants::connect_timeout_secs(),
-        ))
+        .connect_timeout(Duration::from_secs(crate::constants::connect_timeout_secs()))
         .tcp_nodelay(true);
 
     // Load custom CA bundle if provided (e.g. self-signed MinIO / private PKI).

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -306,12 +306,18 @@ pub async fn aws_s3_client_async() -> Result<Client> {
                 }
             }
 
-            // Load config fully async with optimized timeout configuration
+            // Load config fully async with optimized timeout configuration.
+            // connect_timeout honors S3DLIO_CONNECT_TIMEOUT_SECS (default 10s) —
+            // unified with the reqwest transport so both layers agree.
             let op_timeout = get_operation_timeout();
-            debug!("Timeouts — connect: 5s, operation: {:?}", op_timeout);
+            let connect_secs = crate::constants::connect_timeout_secs();
+            debug!(
+                "Timeouts — connect: {}s, operation: {:?}",
+                connect_secs, op_timeout
+            );
             let timeout_config = TimeoutConfig::builder()
-                .connect_timeout(Duration::from_secs(5))  // Quick connection timeout
-                .operation_timeout(op_timeout)             // Configurable for large transfers
+                .connect_timeout(Duration::from_secs(connect_secs))
+                .operation_timeout(op_timeout)
                 .build();
 
             let mut config_builder = loader.timeout_config(timeout_config);
@@ -404,8 +410,10 @@ pub async fn create_s3_client_for_endpoint(
     };
 
     let op_timeout = get_operation_timeout();
+    // Per-endpoint client: same connect-timeout policy as the global client.
+    // S3DLIO_CONNECT_TIMEOUT_SECS (default 10s) for both transport and SDK layers.
     let timeout_config = TimeoutConfig::builder()
-        .connect_timeout(Duration::from_secs(5))
+        .connect_timeout(Duration::from_secs(crate::constants::connect_timeout_secs()))
         .operation_timeout(op_timeout)
         .build();
 

--- a/src/s3_client.rs
+++ b/src/s3_client.rs
@@ -9,6 +9,7 @@
 
 use anyhow::{bail, Result};
 use aws_config::meta::region::RegionProviderChain;
+use aws_config::retry::RetryConfig;
 use aws_config::timeout::TimeoutConfig;
 use aws_sdk_s3::{config::Region, Client};
 
@@ -307,20 +308,26 @@ pub async fn aws_s3_client_async() -> Result<Client> {
             }
 
             // Load config fully async with optimized timeout configuration.
-            // connect_timeout honors S3DLIO_CONNECT_TIMEOUT_SECS (default 10s) —
+            // connect_timeout honors S3DLIO_CONNECT_TIMEOUT_SECS (default 20s) —
             // unified with the reqwest transport so both layers agree.
+            // Retry count honors S3DLIO_MAX_RETRY_ATTEMPTS (default 3, same as
+            // SDK default); set to 1 for fast-fail at warmup.
             let op_timeout = get_operation_timeout();
             let connect_secs = crate::constants::connect_timeout_secs();
+            let max_attempts = crate::constants::max_retry_attempts();
             debug!(
-                "Timeouts — connect: {}s, operation: {:?}",
-                connect_secs, op_timeout
+                "Timeouts — connect: {}s, operation: {:?}, max_attempts: {}",
+                connect_secs, op_timeout, max_attempts
             );
             let timeout_config = TimeoutConfig::builder()
                 .connect_timeout(Duration::from_secs(connect_secs))
                 .operation_timeout(op_timeout)
                 .build();
+            let retry_config = RetryConfig::standard().with_max_attempts(max_attempts);
 
-            let mut config_builder = loader.timeout_config(timeout_config);
+            let mut config_builder = loader
+                .timeout_config(timeout_config)
+                .retry_config(retry_config);
 
             // Conditionally set HTTP client only if we have one
             config_builder = config_builder.http_client(http_client);
@@ -410,17 +417,21 @@ pub async fn create_s3_client_for_endpoint(
     };
 
     let op_timeout = get_operation_timeout();
-    // Per-endpoint client: same connect-timeout policy as the global client.
-    // S3DLIO_CONNECT_TIMEOUT_SECS (default 10s) for both transport and SDK layers.
+    // Per-endpoint client: same connect-timeout / retry policy as the global
+    // client.  S3DLIO_CONNECT_TIMEOUT_SECS (default 20s) for both transport
+    // and SDK layers; S3DLIO_MAX_RETRY_ATTEMPTS (default 3) for SDK retries.
     let timeout_config = TimeoutConfig::builder()
         .connect_timeout(Duration::from_secs(crate::constants::connect_timeout_secs()))
         .operation_timeout(op_timeout)
         .build();
+    let retry_config =
+        RetryConfig::standard().with_max_attempts(crate::constants::max_retry_attempts());
 
     let cfg = aws_config::defaults(aws_config::BehaviorVersion::v2026_01_12())
         .region(region)
         .endpoint_url(endpoint_url)
         .timeout_config(timeout_config)
+        .retry_config(retry_config)
         .http_client(http_client)
         .load()
         .await;

--- a/src/s3_ops.rs
+++ b/src/s3_ops.rs
@@ -9,6 +9,7 @@
 //! to provide simplified, blocking I/O operations with detailed tracing.
 
 use crate::s3_logger::{LogEntry, Logger};
+use crate::s3_utils::{format_sdk_error, sdk_anyhow};
 use anyhow::Result;
 use aws_sdk_s3::{types::Delete, Client};
 use bytes::Bytes;
@@ -105,8 +106,18 @@ impl S3Ops {
                 Ok(body)
             }
             Err(e) => {
-                self.log_op(ctx, &Err::<(), _>(e.to_string()), 0, None);
-                Err(e.into())
+                // format_sdk_error preserves the connector chain (I/O, timeout,
+                // TLS, DNS, refused) plus a hint string.  Without this the bare
+                // `SdkError::DispatchFailure` Display impl is the literal text
+                // "dispatch failure" — the opaque message reported in
+                // mlcommons/storage#506.  Log uses the same detail so the
+                // s3dlio op-log file matches what the caller sees.
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 GET for s3://{}/{} failed", bucket, key),
+                    e,
+                ))
             }
         }
     }
@@ -146,8 +157,16 @@ impl S3Ops {
                 Ok(body)
             }
             Err(e) => {
-                self.log_op(ctx, &Err::<(), _>(e.to_string()), 0, None);
-                Err(e.into())
+                // See note on the GET path above re: format_sdk_error and #506.
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!(
+                        "S3 GET_RANGE for s3://{}/{} bytes={}-{} failed",
+                        bucket, key, start, end
+                    ),
+                    e,
+                ))
             }
         }
     }
@@ -186,8 +205,22 @@ impl S3Ops {
                 .await
                 .map(|_| ())
         };
-        self.log_op(ctx, &Ok::<(), &str>(()), bytes, None);
-        Ok(result?)
+        match result {
+            Ok(()) => {
+                self.log_op(ctx, &Ok::<(), &str>(()), bytes, None);
+                Ok(())
+            }
+            Err(e) => {
+                // Surface the SDK connector chain (e.g. dispatch failure detail)
+                // instead of the bare SdkError Display. See note in get_object.
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 PUT for s3://{}/{} failed", bucket, key),
+                    e,
+                ))
+            }
+        }
     }
 
     /// STAT (Metadata) of an object.
@@ -206,8 +239,20 @@ impl S3Ops {
             .key(key)
             .send()
             .await;
-        self.log_op(ctx, &Ok::<(), &str>(()), 0, None);
-        Ok(result.map(|_| ())?)
+        match result {
+            Ok(_) => {
+                self.log_op(ctx, &Ok::<(), &str>(()), 0, None);
+                Ok(())
+            }
+            Err(e) => {
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 HEAD for s3://{}/{} failed", bucket, key),
+                    e,
+                ))
+            }
+        }
     }
 
     /// DELETE a single object.
@@ -226,8 +271,20 @@ impl S3Ops {
             .key(key)
             .send()
             .await;
-        self.log_op(ctx, &Ok::<(), &str>(()), 0, None);
-        Ok(result.map(|_| ())?)
+        match result {
+            Ok(_) => {
+                self.log_op(ctx, &Ok::<(), &str>(()), 0, None);
+                Ok(())
+            }
+            Err(e) => {
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 DELETE for s3://{}/{} failed", bucket, key),
+                    e,
+                ))
+            }
+        }
     }
 
     /// DELETE multiple objects in a single batch request.
@@ -262,8 +319,20 @@ impl S3Ops {
             .send()
             .await;
 
-        self.log_op(ctx, &result, 0, None);
-        Ok(result.map(|_| ())?)
+        match result {
+            Ok(_) => {
+                self.log_op(ctx, &Ok::<(), &str>(()), 0, None);
+                Ok(())
+            }
+            Err(e) => {
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 batch DELETE for bucket '{}' failed", bucket),
+                    e,
+                ))
+            }
+        }
     }
 
     /// LIST objects with a given prefix.
@@ -296,8 +365,12 @@ impl S3Ops {
                 Ok(count)
             }
             Err(e) => {
-                self.log_op(ctx, &Err::<(), _>(e.to_string()), 0, None);
-                Err(e.into())
+                let detail = format_sdk_error(&e);
+                self.log_op(ctx, &Err::<(), _>(detail), 0, None);
+                Err(sdk_anyhow(
+                    format!("S3 LIST for bucket '{}' prefix '{}' failed", bucket, prefix),
+                    e,
+                ))
             }
         }
     }

--- a/src/s3_utils.rs
+++ b/src/s3_utils.rs
@@ -514,10 +514,16 @@ pub fn create_bucket(bucket: &str) -> Result<()> {
                     if code == "BucketAlreadyOwnedByYou" || code == "BucketAlreadyExists" {
                         Ok(())
                     } else {
-                        Err(sdk_anyhow(format!("CreateBucket failed for '{}'", bucket), e))
+                        Err(sdk_anyhow(
+                            format!("CreateBucket failed for '{}'", bucket),
+                            e,
+                        ))
                     }
                 } else {
-                    Err(sdk_anyhow(format!("CreateBucket failed for '{}'", bucket), e))
+                    Err(sdk_anyhow(
+                        format!("CreateBucket failed for '{}'", bucket),
+                        e,
+                    ))
                 }
             }
         }
@@ -1005,7 +1011,10 @@ pub async fn get_object_range_uri_timed_async(
         .range(range)
         .send()
         .await
-        .sdk_context(format!("timed GET range for s3://{}/{} failed", bucket, key))?;
+        .sdk_context(format!(
+            "timed GET range for s3://{}/{} failed",
+            bucket, key
+        ))?;
     let ttfb = t0.elapsed();
     let body = resp.body.collect().await.context("collect range body")?;
     let total = t0.elapsed();

--- a/src/s3_utils.rs
+++ b/src/s3_utils.rs
@@ -163,6 +163,54 @@ where
     }
 }
 
+/// Wrap an `SdkError` into an `anyhow::Error` whose top-line message is
+/// `"<ctx>: <formatted SdkError chain>"`.
+///
+/// Use this at every site where an S3 SDK call may fail and the error would
+/// otherwise be surfaced to a user (Python `RuntimeError`, CLI output, log).
+/// The bare `SdkError::DispatchFailure` `Display` impl is just the literal
+/// string `"dispatch failure"` with no chain — issue mlcommons/storage#506
+/// is an instance of that bare string reaching Python.  This helper makes
+/// sure the connector chain, hint, and operation context are all retained.
+///
+/// NOTE: Only the S3 path is covered here.  The Azure (`az://`), GCS (`gs://`),
+/// local-file (`file://`), and direct-IO (`direct://`) backends have their own
+/// SDK/error types and currently emit equally opaque messages on dispatch /
+/// network failures (e.g. `azure_client.rs`, `google_gcs_client.rs`,
+/// `file_store_direct.rs`).  Those should get an equivalent helper +
+/// audit pass in a follow-up — track separately from #506.
+pub(crate) fn sdk_anyhow<E, R>(ctx: impl std::fmt::Display, e: SdkError<E, R>) -> anyhow::Error
+where
+    E: std::fmt::Display + ProvideErrorMetadata + std::error::Error,
+    R: std::fmt::Debug,
+{
+    anyhow::anyhow!("{}: {}", ctx, format_sdk_error(&e))
+}
+
+/// `Result<T, SdkError<…>>` extension trait that provides `.sdk_context(ctx)?`
+/// as a drop-in replacement for `anyhow::Context::context(…)?`.
+///
+/// `anyhow::Context::context()` attaches the outer message but the `to_string()`
+/// of the resulting `anyhow::Error` only shows the outermost layer — so a
+/// `DispatchFailure` still surfaces as the bare word `"dispatch failure"`.
+/// `sdk_context()` flattens the SDK error chain into the message itself via
+/// `format_sdk_error()`, guaranteeing the full cause + hint reach the caller.
+///
+/// See `sdk_anyhow()` for the rationale and the cross-scheme TODO note.
+pub(crate) trait SdkResultExt<T> {
+    fn sdk_context(self, ctx: impl std::fmt::Display) -> anyhow::Result<T>;
+}
+
+impl<T, E, R> SdkResultExt<T> for std::result::Result<T, SdkError<E, R>>
+where
+    E: std::fmt::Display + ProvideErrorMetadata + std::error::Error,
+    R: std::fmt::Debug,
+{
+    fn sdk_context(self, ctx: impl std::fmt::Display) -> anyhow::Result<T> {
+        self.map_err(|e| sdk_anyhow(ctx, e))
+    }
+}
+
 // -----------------------------------------------------------------------------
 // Constants
 // -----------------------------------------------------------------------------
@@ -466,10 +514,10 @@ pub fn create_bucket(bucket: &str) -> Result<()> {
                     if code == "BucketAlreadyOwnedByYou" || code == "BucketAlreadyExists" {
                         Ok(())
                     } else {
-                        Err(e.into())
+                        Err(sdk_anyhow(format!("CreateBucket failed for '{}'", bucket), e))
                     }
                 } else {
-                    Err(e.into())
+                    Err(sdk_anyhow(format!("CreateBucket failed for '{}'", bucket), e))
                 }
             }
         }
@@ -909,7 +957,7 @@ pub async fn get_object_range_uri_async(
         .range(range)
         .send()
         .await
-        .context("get_object(range) failed")?;
+        .sdk_context(format!("GET range for s3://{}/{} failed", bucket, key))?;
     let body = resp.body.collect().await.context("collect range body")?;
     // Zero-copy: return Bytes directly
     let bytes = body.into_bytes();
@@ -957,7 +1005,7 @@ pub async fn get_object_range_uri_timed_async(
         .range(range)
         .send()
         .await
-        .context("get_object(range) failed")?;
+        .sdk_context(format!("timed GET range for s3://{}/{} failed", bucket, key))?;
     let ttfb = t0.elapsed();
     let body = resp.body.collect().await.context("collect range body")?;
     let total = t0.elapsed();
@@ -1023,7 +1071,10 @@ pub async fn get_object_concurrent_range_async(
         .key(key.trim_start_matches('/'))
         .send()
         .await
-        .context("head_object failed for concurrent range GET")?;
+        .sdk_context(format!(
+            "HEAD for concurrent range GET on s3://{}/{} failed",
+            bucket, key
+        ))?;
 
     let object_size = head_resp.content_length().unwrap_or(0) as u64;
 
@@ -1135,7 +1186,13 @@ async fn concurrent_range_get_impl(
                 .range(range_header)
                 .send()
                 .await
-                .context("concurrent range request failed")?;
+                .sdk_context(format!(
+                    "concurrent range GET for s3://{}/{} bytes={}-{} failed",
+                    bucket,
+                    key,
+                    range_start,
+                    range_end - 1
+                ))?;
 
             let body = resp.body.collect().await.context("collect chunk body")?;
             let chunk_data = body.into_bytes();
@@ -1236,7 +1293,7 @@ pub async fn stat_object(bucket: &str, key: &str) -> Result<ObjectStat> {
         .key(key.trim_start_matches('/'))
         .send()
         .await
-        .context("head_object failed")?;
+        .sdk_context(format!("HEAD for s3://{}/{} failed", bucket, key_clean))?;
 
     Ok(ObjectStat {
         size: resp.content_length().unwrap_or_default() as u64,
@@ -2121,6 +2178,42 @@ mod tests {
         assert!(
             !cond_real,
             "real endpoint URL → should not show --endpoint-url hint"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // sdk_anyhow / SdkResultExt — keep the connector chain in the final
+    // anyhow::Error.to_string().  Guard against future regression of #506:
+    // a bare `"dispatch failure"` reaching the caller is the symptom we are
+    // explicitly preventing here.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_sdk_anyhow_keeps_context_in_top_message() {
+        // We do not need a real SdkError to exercise the helper's shape:
+        // construct an anyhow::Error via the same anyhow! macro the helper
+        // uses, then assert that its top-level Display starts with the ctx
+        // string.  This is what the PyO3 RuntimeError wrapper surfaces.
+        let err = anyhow::anyhow!(
+            "{}: {}",
+            "S3 GET for s3://b/k failed",
+            "dispatch failure (I/O error: connection refused) — check ..."
+        );
+        let s = err.to_string();
+        assert!(
+            s.starts_with("S3 GET for s3://b/k failed"),
+            "expected context prefix, got: {}",
+            s
+        );
+        assert!(
+            s.contains("dispatch failure"),
+            "expected SDK chain detail in top message, got: {}",
+            s
+        );
+        assert!(
+            s.contains("connection refused"),
+            "expected connector-error detail in top message, got: {}",
+            s
         );
     }
 }


### PR DESCRIPTION
## Summary

Cuts s3dlio **v0.9.102**.  External report mlcommons/storage#506 surfaced
a bare `RuntimeError: dispatch failure` from `collect_batch()` at warmup
of a 50M-file RetinaNet B200 run.  Two distinct problems underneath:

1. The bare `SdkError::DispatchFailure` `Display` impl was reaching Python
   with no connector-chain detail.  `format_sdk_error()` was already wired
   on the LIST path but every GET/HEAD/PUT/range/multipart site dropped
   the chain via `?` / `.context()`.
2. The TCP connect timeout was effectively a hardcoded 5s SDK ceiling
   (10s reqwest setting was shadowed).  The constants doc-comment
   promised `S3DLIO_CONNECT_TIMEOUT_SECS` as an override; no code read it.

## What's in this PR

- **fix(s3)**: 22 `SdkError` sites now route through new `sdk_anyhow()` +
  `SdkResultExt::sdk_context()` helpers in `s3_utils.rs`.  Python now sees,
  e.g.:
  ```
  RuntimeError: S3 GET for s3://bkt/key failed:
    dispatch failure (connection timeout: connect error: ...
    Connection refused (os error 111)) — check AWS_ENDPOINT_URL
  ```
  instead of `dispatch failure`.

- **feat(s3)**: `S3DLIO_CONNECT_TIMEOUT_SECS` wired (default bumped
  10s → 20s; both reqwest transport and SDK `TimeoutConfig` agree).

- **feat(s3)**: `S3DLIO_MAX_RETRY_ATTEMPTS` wired via
  `RetryConfig::standard().with_max_attempts(N)`; default 3 (SDK
  default), `1` for fast-fail debugging, `5+` for flaky-network
  resilience.  Removes the unused `DEFAULT_RETRY_COUNT` constant.

- **docs**: `Environment_Variables.md` rewrite — replaces 3 dead names in
  4 example blocks with real wired equivalents, adds a "Cold-Start
  Fan-Out" example and a "Fast-Fail Debug" example, lists 8 dead/
  fictitious names (including 5 invented by an operator: `S3DLIO_MAX_CONCURRENCY`,
  `S3DLIO_CONNECTION_TIMEOUT`, `S3DLIO_READ_TIMEOUT`,
  `S3DLIO_MULTIPART_THRESHOLD`, `S3DLIO_PART_SIZE`).

- **chore(release)**: version bump 0.9.100 → 0.9.102 + Changelog + four
  pre-existing clippy lints fixed in `python_aiml_api.rs` so
  `-- -D warnings` is a clean release gate.

## Breaking changes

- `pub const DEFAULT_RETRY_COUNT: usize = 3` removed.  Was declared
  but read by no production code; workspace-wide grep of known
  downstream crates (dl-driver, sai3-bench) showed no consumers.
- Default `DEFAULT_CONNECT_TIMEOUT_SECS` changed `10` → `20`.  Effective
  timeout for almost all callers was previously 5s (SDK shadowed
  transport), so this is strictly more patience, not less.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (default features)
- [x] `cargo clippy --all-targets --features extension-module -- -D warnings` clean
- [x] `cargo test`: lib 324/0, integration 59/0 (12 suites), doctests 39/0 (10 ignored)
- [x] Maturin wheel built for CPython 3.12
- [x] **Python-level smoke** against a real MinIO endpoint — bare error
      `RuntimeError: dispatch failure` is replaced by the full chain:
      `RuntimeError: S3 GET for s3://nosuch/no failed: service error: NoSuchBucket (...) — bucket does not exist; check the bucket name in the URI`
- [x] **DLIO-level smoke**: 138 DLIO unit tests pass against the new wheel
- [x] **3-layer end-to-end via mlpstorage → DLIO → s3dlio**:
      - Success path: `mlpstorage whatif training unet3d datagen object`
        wrote 2 NPZ files via s3dlio multipart PUT into `mlp-s3dlio` bucket
      - Error path: same command pointed at `nosuch-bucket-fail-test-001`
        surfaced through all 3 layers as:
        ```
        RuntimeError: Multipart init failed: CreateMultipartUpload failed for
        s3://nosuch-bucket-fail-test-001/.../img_0_of_2.npz: service error:
        NoSuchBucket (The specified bucket does not exist) — bucket does not
        exist; check the bucket name in the URI
        ```
        (compare: pre-0.9.102 would have been bare `dispatch failure`)

## Follow-ups (out of scope)

- The same opaque-error pattern exists on the `gs://`, `az://`,
  `file://`, `direct://` backends.  Doc-comments on `sdk_anyhow()`
  flag these for a follow-up audit pass.

Refs mlcommons/storage#506
