### PR TITLE
feat(azure): migrate to stable Rust SDK 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,7 +275,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -286,7 +286,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -636,7 +636,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -742,7 +742,7 @@ checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -866,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "azure_core"
-version = "0.31.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe45c6bd7ce3a592327ee4e35b5bd16681714c4443c8a9884abb5731cc4d833"
+checksum = "4e41cbd819986ba41904c207d8ffc4106f8f8352a548d773e9554906379bb2fb"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -879,6 +879,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
+ "tokio",
  "tracing",
  "typespec",
  "typespec_client_core",
@@ -886,21 +887,21 @@ dependencies = [
 
 [[package]]
 name = "azure_core_macros"
-version = "0.5.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190d6e0622d17e2a28239b55d2829d98b348269adcd4ab86a21d3304aa3500cb"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "tracing",
 ]
 
 [[package]]
 name = "azure_identity"
-version = "0.31.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c0c8cb8886f2bdabb3501476fa53f87fa9efea9d457ff991c5ce80052c4774"
+checksum = "32edf96b356ca7c51d7590c4925cc36efc3947a5da4468e8e0b25c56ecbb3de5"
 dependencies = [
  "async-lock",
  "async-trait",
@@ -916,20 +917,21 @@ dependencies = [
 
 [[package]]
 name = "azure_storage_blob"
-version = "0.8.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddcbde7495a00fe7f4aa50ee48ffa3f26ba5be97d8134d450cac198e00618c9"
+checksum = "1756febbcca86c862ef718b983b505d08bd65a9bc984a915b0a16af4a4c3fe5b"
 dependencies = [
+ "async-stream",
  "async-trait",
  "azure_core",
  "bytes",
  "futures 0.3.32",
+ "percent-encoding",
  "pin-project",
  "serde",
  "serde_json",
  "time",
- "url",
- "uuid",
+ "tokio",
 ]
 
 [[package]]
@@ -1058,7 +1060,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1199,7 +1201,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1650,7 +1652,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1663,7 +1665,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1674,7 +1676,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1685,7 +1687,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1739,7 +1741,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1752,7 +1754,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1781,7 +1783,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1794,7 +1796,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1847,7 +1849,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1940,7 +1942,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1960,7 +1962,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1976,7 +1978,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2093,21 +2095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2184,7 +2171,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2239,7 +2226,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "token-source",
  "tokio",
@@ -2254,7 +2241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd3152612316be627be52fe9ca72331eb48425059b3a6a700e7adde223e061d5"
 dependencies = [
  "reqwest 0.13.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -2281,7 +2268,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "token-source",
  "tokio",
@@ -2301,7 +2288,7 @@ dependencies = [
  "gprimitives",
  "gsys",
  "paste",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2315,7 +2302,7 @@ dependencies = [
  "scale-decode",
  "scale-encode",
  "scale-info",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2442,7 +2429,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "url",
@@ -2463,7 +2450,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -2481,7 +2468,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "lazy_static",
  "opentelemetry",
  "opentelemetry-semantic-conventions",
@@ -2494,7 +2481,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tonic 0.14.6",
@@ -2586,7 +2573,7 @@ dependencies = [
  "hex",
  "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "md5",
  "percent-encoding",
  "pin-project",
@@ -2596,7 +2583,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2626,7 +2613,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "url",
 ]
@@ -2645,7 +2632,7 @@ dependencies = [
  "scale-decode",
  "scale-encode",
  "scale-info",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2677,7 +2664,7 @@ dependencies = [
  "hex",
  "parity-scale-codec",
  "scale-info",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "waker-fn",
 ]
 
@@ -2690,7 +2677,7 @@ dependencies = [
  "gprimitives",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2810,7 +2797,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2997,7 +2984,7 @@ dependencies = [
  "hwlocality-sys",
  "libc",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "windows-sys 0.61.2",
 ]
 
@@ -3047,9 +3034,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3089,7 +3076,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.2",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "rustls 0.23.41",
  "rustls-native-certs",
@@ -3104,26 +3091,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.10.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -3139,12 +3110,12 @@ dependencies = [
  "futures-util",
  "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3300,7 +3271,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3405,7 +3376,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3468,7 +3439,7 @@ dependencies = [
  "jni-sys",
  "log",
  "simd_cesu8",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "walkdir",
  "windows-link",
 ]
@@ -3483,7 +3454,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3502,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3779,23 +3750,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3858,7 +3812,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4010,7 +3964,7 @@ dependencies = [
  "http-body-util",
  "httparse",
  "humantime",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "itertools 0.14.0",
  "md-5 0.10.6",
  "parking_lot",
@@ -4023,7 +3977,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -4050,47 +4004,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4102,7 +4019,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4124,7 +4041,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4187,7 +4104,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4306,7 +4223,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4414,7 +4331,7 @@ dependencies = [
  "spin",
  "symbolic-demangle",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -4433,7 +4350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4532,7 +4449,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -4546,7 +4463,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4559,7 +4476,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4572,7 +4489,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4660,7 +4577,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4673,7 +4590,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4687,9 +4604,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -4697,9 +4614,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -4718,8 +4635,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.41",
- "socket2 0.6.4",
- "thiserror 2.0.18",
+ "socket2 0.5.10",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -4742,7 +4659,7 @@ dependencies = [
  "rustls 0.23.41",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4757,9 +4674,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4951,7 +4868,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5003,13 +4920,11 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.27.9",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5021,7 +4936,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -5049,7 +4963,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
@@ -5090,7 +5004,7 @@ dependencies = [
  "http 1.4.2",
  "reqwest 0.13.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tower-service",
 ]
 
@@ -5164,7 +5078,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5235,7 +5149,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5280,7 +5194,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s3dlio"
-version = "0.9.112"
+version = "0.9.114"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -5325,7 +5239,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hwlocality",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-util",
  "indicatif",
  "io",
@@ -5373,7 +5287,7 @@ dependencies = [
 
 [[package]]
 name = "s3dlio-oplog"
-version = "0.9.112"
+version = "0.9.114"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5423,7 +5337,7 @@ dependencies = [
  "scale-decode-derive",
  "scale-type-resolver",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5435,7 +5349,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5450,7 +5364,7 @@ dependencies = [
  "scale-encode-derive",
  "scale-type-resolver",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -5463,7 +5377,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5487,7 +5401,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5624,7 +5538,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5681,7 +5595,7 @@ dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5793,7 +5707,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
 ]
 
@@ -5896,7 +5810,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5940,6 +5854,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5956,7 +5881,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5983,10 +5908,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6026,11 +5951,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -6041,18 +5966,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6082,7 +6007,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
 dependencies = [
  "deranged",
- "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -6185,17 +6109,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6309,7 +6223,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6335,7 +6249,7 @@ dependencies = [
  "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.10.1",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -6456,7 +6370,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6532,14 +6446,14 @@ checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "typespec"
-version = "0.11.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd1eb4a538c1ab3d5c05437129bc16891296146b23c9b0bb3f5df99f5b3a18d"
+checksum = "753a2fe021e407d4fc9ee6f4f0a33403cc306d5c54c4e4ebe1b8cbde0ca052b9"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures 0.3.32",
- "quick-xml 0.38.4",
+ "quick-xml 0.41.0",
  "serde",
  "serde_json",
  "url",
@@ -6547,18 +6461,18 @@ dependencies = [
 
 [[package]]
 name = "typespec_client_core"
-version = "0.10.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e632235c99ae896a3c451d1ead00cea11a2219aeda1b35a74027fe99ea3f3b72"
+checksum = "0373af0f9d4f580b3a1a9d9639cedaabe015ed262b35bfbe13941bfb14fe1ea6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
+ "bytes",
  "dyn-clone",
  "futures 0.3.32",
- "getrandom 0.3.4",
  "pin-project",
- "rand 0.9.4",
- "reqwest 0.12.28",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "time",
@@ -6572,14 +6486,14 @@ dependencies = [
 
 [[package]]
 name = "typespec_macros"
-version = "0.10.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7048df3b053daa72e8ea91894ebcb2f0511ba52737379834524d82074a94a458"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6702,9 +6616,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -6716,12 +6630,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6817,7 +6725,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -6925,7 +6833,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6955,7 +6863,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6966,7 +6874,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7101,7 +7009,7 @@ checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
  "serde",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7160,7 +7068,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7181,7 +7089,7 @@ checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7201,7 +7109,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -7222,7 +7130,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7255,7 +7163,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7270,7 +7178,7 @@ dependencies = [
  "displaydoc",
  "indexmap 2.14.0",
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,9 @@ members = [".", "crates/s3dlio-oplog"]
 
 # Workspace-level package metadata that can be inherited by all members
 [workspace.package]
-version = "0.9.112"
+version = "0.9.114"
 edition = "2021"
+rust-version = "1.88"
 authors = ["Russ Fellows"]
 license = "Apache-2.0"
 
@@ -12,6 +13,7 @@ license = "Apache-2.0"
 name = "s3dlio"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 
 [lib]
 name = "s3dlio"
@@ -31,13 +33,10 @@ path = "src/bin/cli.rs"
 aws-config         = "1"
 aws-sdk-s3         = "1"
 
-# Azure SDK crates - kept at exact 0.31 / 0.8 pins. These three reached 1.0
-# in early 2026, but that upgrade is deliberately deferred (Azure API surface
-# has non-trivial breaking changes at 0.x → 1.0; will be tackled as its own
-# task, separately from the AWS-side updates above).
-azure_core = { version = "=0.31.0", optional = true }          # Response/Body, paging, errors
-azure_identity = { version = "=0.31.0", optional = true }      # DefaultAzureCredential
-azure_storage_blob = { version = "=0.8.0", optional = true }   # Blob/Container/BlockBlob clients
+# Azure SDK stable 1.x line. Pre-release versions are intentionally excluded.
+azure_core = { version = "1", optional = true }
+azure_identity = { version = "1", optional = true }
+azure_storage_blob = { version = "1", optional = true }
 
 # Google Cloud Storage SDK
 # 'backend-gcs' enables official gRPC GCS support (google-cloud-rust).

--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 [![Build Status](https://img.shields.io/badge/build-passing-brightgreen)](https://github.com/russfellows/s3dlio)
 [![Rust Tests](https://img.shields.io/badge/rust%20tests-762-brightgreen)](docs/Changelog.md)
-[![Version](https://img.shields.io/badge/version-0.9.112-blue)](https://github.com/russfellows/s3dlio/releases)
+[![Version](https://img.shields.io/badge/version-0.9.114-blue)](https://github.com/russfellows/s3dlio/releases)
 [![PyPI](https://img.shields.io/pypi/v/s3dlio)](https://pypi.org/project/s3dlio/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-1.91%2B-orange)](https://www.rust-lang.org)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org)
 
 High-performance, multi-protocol storage library for AI/ML workloads with universal copy operations across S3, Azure, GCS, local file systems, and DirectIO.
+
+Full-backend builds support the stable Azure Blob Storage Rust SDK 1.0 API.
 
 > **v0.9.112 — Tokio-runtime sanity clamp + MPI-aware thread pools + FFI-boundary hardening**
 >
@@ -657,7 +659,7 @@ See [S3DLIO OpLog Implementation](docs/S3DLIO_OPLOG_IMPLEMENTATION_SUMMARY.md) f
 ## Building from Source
 
 ### Prerequisites
-- **Rust**: [Install Rust toolchain](https://www.rust-lang.org/tools/install)
+- **Rust 1.88+**: [Install Rust toolchain](https://www.rust-lang.org/tools/install)
 - **Python 3.12+**: For Python library development
 - **UV** (recommended): [Install UV](https://docs.astral.sh/uv/getting-started/installation/)
 - **OpenSSL**: Required (`libssl-dev` on Ubuntu)

--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -1,5 +1,26 @@
 # s3dlio Changelog
 
+## Version 0.9.114 — Azure SDK stable 1.x migration
+
+- Updated `azure_storage_blob` and `azure_identity` from pre-release APIs to
+  stable 1.0, with `azure_core` on the compatible stable 1.x line.
+- Added configurable Azure download strategies: `auto`, `azure-sdk`, `s3dlio`,
+  and `sequential`. `auto` uses sequential transfer below the configured
+  threshold and selects either Azure SDK managed partitioning or s3dlio's
+  RangeEngine above it.
+- Added Azure SDK partition concurrency and size controls. Explicit Rust
+  `AzureConfig` values override environment-derived defaults.
+- Reused one `BlobServiceClient` pipeline per `AzureBlob` instead of rebuilding
+  a client pipeline for each operation and staged block.
+- Preserved zero-copy upload bodies by using Azure Core's `From<Bytes>` request
+  conversion. A pointer-identity regression test covers sliced `Bytes` values.
+- Restored container create/delete support exposed by the stable SDK.
+- Custom Azure-compatible endpoints remain supported structurally. Additional
+  generic-target authentication and live endpoint validation are tracked as a
+  follow-up after real Azure Blob validation; this migration does not remove
+  the custom endpoint settings.
+- Raised the Rust MSRV to 1.88, required by Azure Storage Blob 1.0.
+
 ## Version 0.9.112 — Tokio-runtime sanity clamp + MPI-aware thread pools + FFI-boundary hardening
 
 This release bundles three independent hardening changes: (1) a sanity

--- a/docs/Environment_Variables.md
+++ b/docs/Environment_Variables.md
@@ -355,15 +355,25 @@ When a URI's authority contains an explicit `host:port`, s3dlio creates a dedica
 
 ## Azure Blob Storage Configuration
 
-| Variable | Description |
-|----------|-------------|
-| `AZURE_STORAGE_ACCOUNT` | Azure storage account name |
-| `AZURE_STORAGE_KEY` | Azure storage account key |
-| `AZURE_CLIENT_ID` | Azure AD client ID (for service principal auth) |
-| `AZURE_CLIENT_SECRET` | Azure AD client secret |
-| `AZURE_TENANT_ID` | Azure AD tenant ID |
-| `AZURE_STORAGE_ENDPOINT` | **Custom Azure endpoint** (e.g., `http://localhost:10000` for Azurite) |
-| `AZURE_BLOB_ENDPOINT_URL` | Alternative for `AZURE_STORAGE_ENDPOINT` |
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AZURE_STORAGE_ACCOUNT` | (unset) | Azure storage account name |
+| `AZURE_STORAGE_KEY` | (unset) | Azure storage account key |
+| `AZURE_CLIENT_ID` | (unset) | Azure AD client ID (for service principal auth) |
+| `AZURE_CLIENT_SECRET` | (unset) | Azure AD client secret |
+| `AZURE_TENANT_ID` | (unset) | Azure AD tenant ID |
+| `AZURE_STORAGE_ENDPOINT` | (unset) | **Custom Azure endpoint** (e.g., `http://localhost:10000` for Azurite) |
+| `AZURE_BLOB_ENDPOINT_URL` | (unset) | Alternative for `AZURE_STORAGE_ENDPOINT` |
+| `S3DLIO_AZURE_DOWNLOAD_MODE` | `auto` | Download strategy: `auto`, `azure-sdk`, `s3dlio`, or `sequential` |
+| `S3DLIO_AZURE_CONCURRENT_ENGINE` | `azure-sdk` | Concurrent engine selected by `auto`: `azure-sdk` or `s3dlio` |
+| `S3DLIO_AZURE_DOWNLOAD_THRESHOLD_MB` | `32` | Object size at which `auto` enables its concurrent engine |
+| `S3DLIO_AZURE_DOWNLOAD_CONCURRENCY` | `16` | Parallel requests used by Azure SDK managed downloads |
+| `S3DLIO_AZURE_DOWNLOAD_PART_SIZE_MB` | `32` | Partition size used by Azure SDK managed downloads |
+
+Explicit fields supplied through Rust `AzureConfig` take precedence over these
+environment-derived defaults. The legacy `AzureConfig.enable_range_engine=true`
+setting remains supported and forces the s3dlio RangeEngine above its configured
+threshold.
 
 ### Azure Custom Endpoint Examples
 
@@ -555,6 +565,7 @@ export S3DLIO_ENABLE_RANGE_OPTIMIZATION=0    # disable range-split GETs
 
 ## Version History
 
+- **v0.9.114** *(Azure SDK stable 1.x migration)*: Updated Azure Blob Storage and identity clients to the stable 1.x SDK line. Added `S3DLIO_AZURE_DOWNLOAD_MODE`, `S3DLIO_AZURE_CONCURRENT_ENGINE`, `S3DLIO_AZURE_DOWNLOAD_THRESHOLD_MB`, `S3DLIO_AZURE_DOWNLOAD_CONCURRENCY`, and `S3DLIO_AZURE_DOWNLOAD_PART_SIZE_MB` for selecting and tuning Azure SDK managed downloads, s3dlio RangeEngine downloads, or sequential transfers. Raised the Rust MSRV to 1.88. Full changelog: [`docs/Changelog.md`](Changelog.md).
 - **v0.9.112** *(new: `S3DLIO_RT_THREADS_UNSAFE`; behavior change: `S3DLIO_RT_THREADS` sanity clamp)*: Added a sanity clamp to `S3DLIO_RT_THREADS` — values below `RT_THREADS_LIMIT/4` are treated as downstream miscomputation and clamped up to `RT_THREADS_LIMIT`, with a stderr warning the first time it fires.  Rationale: the DLIO unet3d datagen bottleneck (2026-07-10, `docs/investigation/DLIO_UNET3D_DATAGEN_BOTTLENECK_INVESTIGATION_2026-07-10.md`) was caused by DLIO's `ObjStoreLibStorage.__init__` computing `S3DLIO_RT_THREADS = write_threads * 1.5` with Hydra's default `write_threads=1`, giving `S3DLIO_RT_THREADS=1` and building a 1-worker Tokio runtime that serialized every concurrent multipart upload part (10× throughput loss, live-measured 214 MB/s vs 1928 MB/s after fix on a 28-core host with s3-ultra).  `S3DLIO_RT_THREADS_UNSAFE=1` bypasses the clamp for legitimate low-thread scenarios (single-threaded test suites, fault-injection).  The clamp is inactive when `configure_thread_pools` was never called (`RT_THREADS_LIMIT=0`), preserving pure-Rust programmatic use.  Also in v0.9.112: FFI-boundary
   hardening (mlcommons/storage#755, s3dlio#161, s3dlio#162). Error conversion at
   the PyO3 boundary now preserves the full `anyhow` cause chain instead of just

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3dlio"
-version = "0.9.112"
+version = "0.9.114"
 description = "High-performance Object Storage Library for Pytorch, Jax and Tensorflow: Object support inlcudes S3, Azure, GCS, and file system operations for AI/ML"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/python/tests/bench_multipart_vs_s3torchconnector.py
+++ b/python/tests/bench_multipart_vs_s3torchconnector.py
@@ -15,7 +15,6 @@ to confirm s3dlio is competitive.
 Run against real MinIO (from s3dlio/.env):
   cd ~/Documents/Code/s3dlio && source .venv/bin/activate
   set -a && source .env && set +a
-  AWS_CA_BUNDLE=/home/eval/Documents/Code/mlp-storage/.certs/public.crt \\
   S3DLIO_TEST_BUCKET=perf-s3dlio \\
   python python/tests/bench_multipart_vs_s3torchconnector.py
 """

--- a/python/tests/test_issue134_backpressure.py
+++ b/python/tests/test_issue134_backpressure.py
@@ -19,7 +19,6 @@ These tests verify the contract of the correct fix:
 Run against real MinIO (from s3dlio/.env):
   cd ~/Documents/Code/s3dlio && source .venv/bin/activate
   set -a && source .env && set +a
-  AWS_CA_BUNDLE=/home/eval/Documents/Code/mlp-storage/.certs/public.crt \
   S3DLIO_TEST_BUCKET=perf-s3dlio \
   python python/tests/test_issue134_backpressure.py
 

--- a/python/tests/test_mpu_throughput.py
+++ b/python/tests/test_mpu_throughput.py
@@ -7,7 +7,6 @@ AWS_ENDPOINT_URL is not set or the server is unreachable.
 Run:
   cd ~/Documents/Code/s3dlio && source .venv/bin/activate
   set -a && source .env && set +a
-  AWS_CA_BUNDLE=/home/eval/Documents/Code/mlp-storage/.certs/public.crt \\
   S3DLIO_TEST_BUCKET=perf-s3dlio \\
   python python/tests/test_mpu_throughput.py
 

--- a/src/azure_client.rs
+++ b/src/azure_client.rs
@@ -6,6 +6,7 @@
 use anyhow::{anyhow, bail, Result};
 use bytes::Bytes;
 use futures::{stream::FuturesUnordered, Stream, StreamExt};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use tokio::sync::OnceCell;
 use tokio::task::JoinHandle;
@@ -14,18 +15,17 @@ use tokio_util::sync::CancellationToken;
 use crate::data_loader::parallel_fetch::DropCancel;
 
 use azure_core::credentials::TokenCredential;
-use azure_core::http::{Body, NoFormat, RequestContent, XmlFormat};
+use azure_core::http::{NoFormat, RequestContent, Url, XmlFormat};
 use azure_identity::DeveloperToolsCredential;
 
 use azure_storage_blob::clients::{
-    BlobClient, BlobClientOptions, BlobContainerClient, BlobContainerClientOptions,
-    BlobServiceClient, BlobServiceClientOptions, BlockBlobClient,
+    BlobClient, BlobContainerClient, BlobServiceClient, BlobServiceClientOptions, BlockBlobClient,
 };
 use azure_storage_blob::models::{
     BlobClientDownloadOptions, BlobClientGetPropertiesOptions,
-    BlobClientGetPropertiesResultHeaders, BlobContainerClientListBlobFlatSegmentOptions,
-    BlockBlobClientCommitBlockListOptions, BlockBlobClientStageBlockOptions,
-    BlockBlobClientUploadOptions, BlockList, BlockListType, BlockLookupList,
+    BlobClientGetPropertiesResultHeaders, BlobClientUploadOptions,
+    BlobContainerClientListBlobsOptions, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientStageBlockOptions, BlockList, BlockListType, BlockLookupList, HttpRange,
 };
 use tracing::{debug, warn};
 
@@ -41,6 +41,10 @@ static AZURE_CREDENTIAL: OnceCell<Arc<dyn TokenCredential>> = OnceCell::const_ne
 /// fail server-side, with all staged blocks wasted.
 const AZURE_MAX_BLOCK_COUNT: usize = 50_000;
 
+fn request_content_from_bytes(body: Bytes) -> RequestContent<Bytes, NoFormat> {
+    body.into()
+}
+
 /// Minimal properties surfaced by `stat`.
 #[derive(Debug, Clone)]
 pub struct AzureBlobProperties {
@@ -51,9 +55,8 @@ pub struct AzureBlobProperties {
 
 /// High-level client bound to one container.
 pub struct AzureBlob {
-    account_url: String, // e.g. https://{account}.blob.core.windows.net
+    service_client: Arc<BlobServiceClient>,
     pub container: String,
-    credential: Arc<dyn TokenCredential>,
 }
 
 impl AzureBlob {
@@ -92,81 +95,54 @@ impl AzureBlob {
             return Self::with_default_credential_from_url(&account_url, container);
         }
 
-        // Default: public Azure endpoint
-        let account_url = Self::account_url_from_account(account);
-
-        // Get or initialize the global credential (only authenticates once per process)
-        let credential = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                AZURE_CREDENTIAL
-                    .get_or_try_init(|| async {
-                        let credential_arc = DeveloperToolsCredential::new(None)?;
-                        let credential: Arc<dyn TokenCredential> = credential_arc;
-                        Ok::<Arc<dyn TokenCredential>, anyhow::Error>(credential)
-                    })
-                    .await
-            })
-        })?;
-
-        Ok(Self {
-            account_url,
-            container: container.to_string(),
-            credential: Arc::clone(credential),
-        })
+        Self::with_default_credential_from_url(&Self::account_url_from_account(account), container)
     }
 
     /// Same, when a full endpoint URL (possibly emulator) is provided.
     pub fn with_default_credential_from_url(account_url: &str, container: &str) -> Result<Self> {
-        // Get or initialize the global credential (only authenticates once per process)
-        let credential = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async {
-                AZURE_CREDENTIAL
-                    .get_or_try_init(|| async {
-                        let credential_arc = DeveloperToolsCredential::new(None)?;
-                        let credential: Arc<dyn TokenCredential> = credential_arc;
-                        Ok::<Arc<dyn TokenCredential>, anyhow::Error>(credential)
-                    })
-                    .await
-            })
-        })?;
+        let service_url = Url::parse(account_url)
+            .map_err(|e| anyhow!("invalid Azure account URL '{account_url}': {e}"))?;
+        let credential = if service_url.scheme() == "https" {
+            Some(tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async {
+                    AZURE_CREDENTIAL
+                        .get_or_try_init(|| async {
+                            let credential_arc = DeveloperToolsCredential::new(None)?;
+                            let credential: Arc<dyn TokenCredential> = credential_arc;
+                            Ok::<Arc<dyn TokenCredential>, anyhow::Error>(credential)
+                        })
+                        .await
+                        .map(Arc::clone)
+                })
+            })?)
+        } else {
+            None
+        };
+        let service_client = BlobServiceClient::new(
+            service_url,
+            credential,
+            Some(BlobServiceClientOptions::default()),
+        )
+        .map_err(|e| anyhow!(e))?;
 
         Ok(Self {
-            account_url: account_url.to_string(),
+            service_client: Arc::new(service_client),
             container: container.to_string(),
-            credential: Arc::clone(credential),
         })
     }
 
     /// Blob service (rarely needed directly).
     #[allow(dead_code)]
-    fn service_client(&self) -> Result<BlobServiceClient> {
-        BlobServiceClient::new(
-            &self.account_url,
-            Some(self.credential.clone()),
-            Some(BlobServiceClientOptions::default()),
-        )
-        .map_err(|e| anyhow!(e))
+    fn service_client(&self) -> Result<Arc<BlobServiceClient>> {
+        Ok(Arc::clone(&self.service_client))
     }
 
     fn container_client(&self) -> Result<BlobContainerClient> {
-        BlobContainerClient::new(
-            &self.account_url,
-            &self.container,
-            Some(self.credential.clone()),
-            Some(BlobContainerClientOptions::default()),
-        )
-        .map_err(|e| anyhow!(e))
+        Ok(self.service_client.blob_container_client(&self.container))
     }
 
     fn blob_client(&self, blob: &str) -> Result<BlobClient> {
-        BlobClient::new(
-            &self.account_url,
-            &self.container,
-            blob,
-            Some(self.credential.clone()),
-            Some(BlobClientOptions::default()),
-        )
-        .map_err(|e| anyhow!(e))
+        Ok(self.service_client.blob_client(&self.container, blob))
     }
 
     fn block_blob_client(&self, blob: &str) -> Result<BlockBlobClient> {
@@ -187,17 +163,9 @@ impl AzureBlob {
             overwrite
         );
         let blob = self.blob_client(key)?;
-        // Convert Bytes -> Body -> RequestContent<Bytes, NoFormat>
-        let content_len = body.len() as u64;
-        let data: RequestContent<Bytes, NoFormat> = Body::from(body).into();
-        let _resp = blob
-            .upload(
-                data,
-                overwrite,
-                content_len,
-                Some(BlockBlobClientUploadOptions::default()),
-            )
-            .await?;
+        let data = request_content_from_bytes(body);
+        let options = (!overwrite).then(|| BlobClientUploadOptions::default().if_not_exists());
+        let _resp = blob.upload(data, options).await?;
         Ok(())
     }
 
@@ -208,14 +176,18 @@ impl AzureBlob {
             self.container, key, start, end
         );
         let blob = self.blob_client(key)?;
-        let mut opts = BlobClientDownloadOptions::default();
         let range = match end {
-            Some(e) => format!("bytes={}-{}", start, e),
-            None => format!("bytes={}-", start),
+            Some(e) if e >= start => HttpRange::new(start, e - start + 1),
+            Some(e) => bail!("invalid Azure byte range: end {e} precedes start {start}"),
+            None => HttpRange::from_offset(start),
         };
-        opts.range = Some(range);
+        let opts = BlobClientDownloadOptions {
+            range: Some(range),
+            parallel: NonZeroUsize::new(1),
+            ..Default::default()
+        };
         let resp = blob.download(Some(opts)).await?;
-        let body = resp.into_body().collect().await?;
+        let body = resp.body.collect().await?;
         debug!(
             "AzureBlob::get_range success: key='{}', {} bytes",
             key,
@@ -226,15 +198,33 @@ impl AzureBlob {
 
     /// Full GET (single buffer).
     pub async fn get(&self, key: &str) -> Result<Bytes> {
+        self.get_with_sdk_concurrency(key, None, None).await
+    }
+
+    pub async fn get_sequential(&self, key: &str, object_size: u64) -> Result<Bytes> {
+        let partition_size = usize::try_from(object_size).unwrap_or(usize::MAX).max(1);
+        self.get_with_sdk_concurrency(key, Some(1), Some(partition_size))
+            .await
+    }
+
+    pub async fn get_with_sdk_concurrency(
+        &self,
+        key: &str,
+        concurrency: Option<usize>,
+        partition_size: Option<usize>,
+    ) -> Result<Bytes> {
         debug!(
             "AzureBlob::get container='{}', key='{}'",
             self.container, key
         );
         let blob = self.blob_client(key)?;
-        let resp = blob
-            .download(Some(BlobClientDownloadOptions::default()))
-            .await?;
-        let body = resp.into_body().collect().await?;
+        let options = BlobClientDownloadOptions {
+            parallel: concurrency.and_then(NonZeroUsize::new),
+            partition_size: partition_size.and_then(NonZeroUsize::new),
+            ..Default::default()
+        };
+        let resp = blob.download(Some(options)).await?;
+        let body = resp.body.collect().await?;
         debug!(
             "AzureBlob::get success: key='{}', {} bytes",
             key,
@@ -275,7 +265,7 @@ impl AzureBlob {
             self.container, prefix
         );
         let container = self.container_client()?;
-        let mut opts = BlobContainerClientListBlobFlatSegmentOptions::default();
+        let mut opts = BlobContainerClientListBlobsOptions::default();
         if let Some(p) = prefix {
             if !p.is_empty() {
                 opts.prefix = Some(p.to_string());
@@ -287,8 +277,7 @@ impl AzureBlob {
         // In 0.7.0, pager yields Result<BlobItemInternal> directly
         while let Some(item_result) = pager.next().await {
             let item = item_result?;
-            // `name` is Option<BlobName>, and BlobName.content is Option<String>
-            if let Some(name) = item.name.and_then(|bn| bn.content) {
+            if let Some(name) = item.name {
                 out.push(name);
             }
         }
@@ -311,7 +300,7 @@ impl AzureBlob {
                 }
             };
 
-            let mut opts = BlobContainerClientListBlobFlatSegmentOptions::default();
+            let mut opts = BlobContainerClientListBlobsOptions::default();
             if let Some(p) = prefix {
                 if !p.is_empty() { opts.prefix = Some(p.to_string()); }
             }
@@ -334,7 +323,7 @@ impl AzureBlob {
                     }
                 };
 
-                if let Some(name) = item.name.and_then(|bn| bn.content) {
+                if let Some(name) = item.name {
                     yield Ok(name);
                 }
             }
@@ -371,7 +360,7 @@ impl AzureBlob {
         );
         let bb = self.block_blob_client(key)?;
         let content_len = chunk.len() as u64;
-        let body: RequestContent<Bytes, NoFormat> = Body::from(chunk).into();
+        let body = request_content_from_bytes(chunk);
         let _resp = bb
             .stage_block(
                 block_id,
@@ -545,9 +534,8 @@ impl AzureBlob {
 
     fn clone_for_upload(&self) -> Self {
         Self {
-            account_url: self.account_url.clone(),
+            service_client: Arc::clone(&self.service_client),
             container: self.container.clone(),
-            credential: self.credential.clone(),
         }
     }
 }
@@ -634,18 +622,19 @@ impl AzureBlob {
     // Container helpers (optional)
     // ----------------------------------------------------------------------
 
-    /// Container creation not supported in newer Azure SDK versions.
-    /// Use Azure CLI, portal, or SDK v0.7 for container management.
     #[allow(dead_code)]
     pub async fn create_container_if_missing(&self) -> Result<()> {
-        bail!("Container creation not supported in Azure SDK v0.8+. Use Azure CLI: az storage container create")
+        let container = self.container_client()?;
+        if !container.exists().await? {
+            container.create(None).await?;
+        }
+        Ok(())
     }
 
-    /// Container deletion not supported in newer Azure SDK versions.
-    /// Use Azure CLI, portal, or SDK v0.7 for container management.
     #[allow(dead_code)]
     pub async fn delete_container(&self) -> Result<()> {
-        bail!("Container deletion not supported in Azure SDK v0.8+. Use Azure CLI: az storage container delete")
+        self.container_client()?.delete(None).await?;
+        Ok(())
     }
 }
 
@@ -697,7 +686,8 @@ pub async fn list_account_containers(account: &str) -> Result<Vec<(String, Optio
         .await?;
 
     let service_client = BlobServiceClient::new(
-        &account_url,
+        Url::parse(&account_url)
+            .map_err(|e| anyhow!("invalid Azure account URL '{account_url}': {e}"))?,
         Some(Arc::clone(credential)),
         Some(BlobServiceClientOptions::default()),
     )
@@ -706,23 +696,16 @@ pub async fn list_account_containers(account: &str) -> Result<Vec<(String, Optio
     let mut containers: Vec<(String, Option<String>)> = Vec::new();
     let mut pager = service_client
         .list_containers(None)
-        .map_err(|e| anyhow!("Azure list_containers failed: {}", e))?
-        .into_pages();
+        .map_err(|e| anyhow!("Azure list_containers failed: {}", e))?;
 
-    while let Some(page) = pager.next().await {
-        let current_page = page
-            .map_err(|e| anyhow!("Azure list_containers page error: {}", e))?
-            .into_model()
-            .map_err(|e| anyhow!("Azure container model deserialisation: {}", e))?;
-
-        for item in current_page.container_items {
-            let name = item.name.unwrap_or_default();
-            let date = item
-                .properties
-                .and_then(|p| p.last_modified)
-                .map(|t| t.to_string());
-            containers.push((name, date));
-        }
+    while let Some(item) = pager.next().await {
+        let item = item.map_err(|e| anyhow!("Azure list_containers item error: {e}"))?;
+        let name = item.name.unwrap_or_default();
+        let date = item
+            .properties
+            .and_then(|p| p.last_modified)
+            .map(|t| t.to_string());
+        containers.push((name, date));
     }
 
     Ok(containers)
@@ -739,6 +722,26 @@ mod tests {
 
     // Mutex to serialize tests that modify environment variables
     static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn request_content_from_bytes_preserves_sliced_allocation() {
+        let source = Bytes::from(vec![7_u8; 4096]);
+        let slice = source.slice(128..3968);
+        let expected_ptr = slice.as_ptr();
+        let expected_len = slice.len();
+
+        let content = request_content_from_bytes(slice);
+        let azure_core::http::Body::Bytes(actual) = content.body() else {
+            panic!("Bytes conversion must produce an in-memory Azure request body");
+        };
+
+        assert_eq!(
+            actual.as_ptr(),
+            expected_ptr,
+            "upload conversion copied data"
+        );
+        assert_eq!(actual.len(), expected_len);
+    }
 
     // RED-then-GREEN regression tests for s3dlio issue #151 bug 1.5 (D4).
     //

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -25,6 +25,27 @@ pub const DEFAULT_S3_MULTIPART_PART_SIZE: usize = 16 * 1024 * 1024;
 /// Default multipart upload part size for Azure (16 MB)
 pub const DEFAULT_AZURE_MULTIPART_PART_SIZE: usize = 16 * 1024 * 1024;
 
+/// Default Azure SDK managed-download partition size (32 MiB).
+pub const DEFAULT_AZURE_DOWNLOAD_PART_SIZE: usize = 32 * 1024 * 1024;
+
+/// Default Azure SDK managed-download concurrency.
+pub const DEFAULT_AZURE_DOWNLOAD_CONCURRENCY: usize = 16;
+
+/// Selects `auto`, `azure-sdk`, `s3dlio`, or `sequential` Azure downloads.
+pub const ENV_AZURE_DOWNLOAD_MODE: &str = "S3DLIO_AZURE_DOWNLOAD_MODE";
+
+/// Selects the concurrent engine used by Azure `auto` mode.
+pub const ENV_AZURE_CONCURRENT_ENGINE: &str = "S3DLIO_AZURE_CONCURRENT_ENGINE";
+
+/// Azure object-size threshold in MiB for switching `auto` mode to concurrency.
+pub const ENV_AZURE_DOWNLOAD_THRESHOLD_MB: &str = "S3DLIO_AZURE_DOWNLOAD_THRESHOLD_MB";
+
+/// Azure SDK managed-download request concurrency.
+pub const ENV_AZURE_DOWNLOAD_CONCURRENCY: &str = "S3DLIO_AZURE_DOWNLOAD_CONCURRENCY";
+
+/// Azure SDK managed-download partition size in MiB.
+pub const ENV_AZURE_DOWNLOAD_PART_SIZE_MB: &str = "S3DLIO_AZURE_DOWNLOAD_PART_SIZE_MB";
+
 /// Maximum number of parts in a multipart upload
 pub const MAX_MULTIPART_PARTS: usize = 10000;
 

--- a/src/list_containers.rs
+++ b/src/list_containers.rs
@@ -396,12 +396,20 @@ mod tests {
     }
 
     #[test]
-    fn test_list_containers_s3_scheme_not_unsupported() {
-        let result = list_containers("s3://");
-        if let Err(e) = result {
+    #[cfg(feature = "backend-azure")]
+    #[ignore = "requires AZURE_BLOB_ACCOUNT, live Azure credentials, and network access"]
+    fn test_list_containers_azure_live() {
+        let account = std::env::var("AZURE_BLOB_ACCOUNT")
+            .expect("AZURE_BLOB_ACCOUNT must be set for the ignored live Azure test");
+        let containers = list_containers(&format!("az://{account}"))
+            .expect("live Azure container listing should succeed");
+        let expected_prefix = format!("az://{account}/");
+        for container in containers {
             assert!(
-                !e.to_string().contains("Unsupported URI scheme"),
-                "s3:// must not hit unsupported-scheme error"
+                container.uri.starts_with(&expected_prefix),
+                "Azure container URI '{}' must use account prefix '{}'",
+                container.uri,
+                expected_prefix
             );
         }
     }
@@ -447,14 +455,13 @@ mod tests {
 
     #[test]
     fn test_list_containers_file_scheme() {
-        // file:// with a real path should successfully list or fail with a path error, not scheme error.
-        let result = list_containers("file:///tmp");
-        if let Err(e) = result {
-            assert!(
-                !e.to_string().contains("Unsupported URI scheme"),
-                "file:// must not hit unsupported-scheme error"
-            );
-        }
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("container")).unwrap();
+        let uri = format!("file://{}", tmp.path().display());
+
+        let containers = list_containers(&uri).expect("file:// URI should list directories");
+        assert_eq!(containers.len(), 1);
+        assert_eq!(containers[0].name, "container");
     }
 
     // ------------------------------------------------------------------

--- a/src/object_store.rs
+++ b/src/object_store.rs
@@ -56,6 +56,12 @@ use crate::file_store_direct::ConfigurableFileSystemObjectStore;
 // --- Azure ---------------------------------------------------
 #[cfg(feature = "backend-azure")]
 use crate::azure_client::{AzureBlob, AzureBlobProperties};
+#[cfg(feature = "backend-azure")]
+use crate::constants::{
+    DEFAULT_AZURE_DOWNLOAD_CONCURRENCY, DEFAULT_AZURE_DOWNLOAD_PART_SIZE,
+    ENV_AZURE_CONCURRENT_ENGINE, ENV_AZURE_DOWNLOAD_CONCURRENCY, ENV_AZURE_DOWNLOAD_MODE,
+    ENV_AZURE_DOWNLOAD_PART_SIZE_MB, ENV_AZURE_DOWNLOAD_THRESHOLD_MB,
+};
 use crate::constants::{
     DEFAULT_RANGE_ENGINE_CHUNK_SIZE, DEFAULT_RANGE_ENGINE_MAX_CONCURRENT,
     DEFAULT_RANGE_ENGINE_THRESHOLD, DEFAULT_RANGE_TIMEOUT_SECS,
@@ -1985,17 +1991,94 @@ fn az_props_to_meta(p: &AzureBlobProperties) -> ObjectMetadata {
     }
 }
 
-/// Configuration for Azure Blob Storage backend with RangeEngine support
+/// Configuration for Azure Blob Storage download behavior.
 ///
-/// Azure benefits significantly from concurrent range downloads due to network latency.
-/// RangeEngine is **disabled by default** — enable explicitly for large-file workloads
-/// where the benefit outweighs the HEAD request cost. Unlike S3, there is no
-/// env-var default for Azure; this config field must be set explicitly.
+/// The default `auto` mode uses sequential transfer below the configured size
+/// threshold and Azure SDK managed concurrency above it. Callers can instead
+/// select s3dlio's RangeEngine or fully sequential downloads through explicit
+/// configuration or the documented Azure environment variables.
+#[cfg(feature = "backend-azure")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AzureDownloadMode {
+    Auto,
+    AzureSdk,
+    S3dlio,
+    Sequential,
+}
+
+#[cfg(feature = "backend-azure")]
+impl std::str::FromStr for AzureDownloadMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "auto" => Ok(Self::Auto),
+            "azure-sdk" | "sdk" | "azure" => Ok(Self::AzureSdk),
+            "s3dlio" | "range-engine" => Ok(Self::S3dlio),
+            "sequential" | "single" => Ok(Self::Sequential),
+            _ => Err(format!(
+                "invalid Azure download mode '{value}'; expected auto, azure-sdk, s3dlio, or sequential"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "backend-azure")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AzureConcurrentEngine {
+    AzureSdk,
+    S3dlio,
+}
+
+#[cfg(feature = "backend-azure")]
+impl std::str::FromStr for AzureConcurrentEngine {
+    type Err = String;
+
+    fn from_str(value: &str) -> std::result::Result<Self, Self::Err> {
+        match value.trim().to_ascii_lowercase().replace('_', "-").as_str() {
+            "azure-sdk" | "sdk" | "azure" => Ok(Self::AzureSdk),
+            "s3dlio" | "range-engine" => Ok(Self::S3dlio),
+            _ => Err(format!(
+                "invalid Azure concurrent engine '{value}'; expected azure-sdk or s3dlio"
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "backend-azure")]
+fn azure_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
+#[cfg(feature = "backend-azure")]
+fn azure_env_mib(name: &str, default_bytes: usize) -> usize {
+    azure_env_usize(name, default_bytes / (1024 * 1024))
+        .checked_mul(1024 * 1024)
+        .unwrap_or(default_bytes)
+}
+
 #[cfg(feature = "backend-azure")]
 #[derive(Debug, Clone)]
 pub struct AzureConfig {
+    /// Download strategy. Explicit config values override environment-derived defaults.
+    pub download_mode: AzureDownloadMode,
+
+    /// Concurrent engine selected by [`AzureDownloadMode::Auto`].
+    pub auto_concurrent_engine: AzureConcurrentEngine,
+
+    /// Azure SDK managed-download concurrency.
+    pub sdk_download_concurrency: usize,
+
+    /// Azure SDK managed-download partition size in bytes.
+    pub sdk_download_part_size: usize,
+
     /// Enable RangeEngine for concurrent range downloads
-    /// Default: false — must be set explicitly for large-file workloads
+    /// Legacy compatibility switch. When true, it selects s3dlio RangeEngine
+    /// above `range_engine.min_split_size` regardless of `download_mode`.
     pub enable_range_engine: bool,
 
     /// RangeEngine configuration
@@ -2013,12 +2096,35 @@ pub struct AzureConfig {
 #[cfg(feature = "backend-azure")]
 impl Default for AzureConfig {
     fn default() -> Self {
+        let download_mode = std::env::var(ENV_AZURE_DOWNLOAD_MODE)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(AzureDownloadMode::Auto);
+        let auto_concurrent_engine = std::env::var(ENV_AZURE_CONCURRENT_ENGINE)
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(AzureConcurrentEngine::AzureSdk);
+        let range_threshold = azure_env_mib(
+            ENV_AZURE_DOWNLOAD_THRESHOLD_MB,
+            DEFAULT_RANGE_ENGINE_THRESHOLD as usize,
+        ) as u64;
+
         Self {
-            enable_range_engine: false, // Disabled by default; must be set explicitly for Azure large-file workloads
+            download_mode,
+            auto_concurrent_engine,
+            sdk_download_concurrency: azure_env_usize(
+                ENV_AZURE_DOWNLOAD_CONCURRENCY,
+                DEFAULT_AZURE_DOWNLOAD_CONCURRENCY,
+            ),
+            sdk_download_part_size: azure_env_mib(
+                ENV_AZURE_DOWNLOAD_PART_SIZE_MB,
+                DEFAULT_AZURE_DOWNLOAD_PART_SIZE,
+            ),
+            enable_range_engine: false,
             range_engine: RangeEngineConfig {
                 chunk_size: DEFAULT_RANGE_ENGINE_CHUNK_SIZE, // 64 MiB chunks
                 max_concurrent_ranges: DEFAULT_RANGE_ENGINE_MAX_CONCURRENT, // 32 parallel
-                min_split_size: DEFAULT_RANGE_ENGINE_THRESHOLD, // 32 MiB threshold (v0.9.60+)
+                min_split_size: range_threshold,
                 range_timeout: Duration::from_secs(DEFAULT_RANGE_TIMEOUT_SECS), // 30s
             },
             size_cache_ttl_secs: 60, // 60 second TTL for size cache
@@ -2078,6 +2184,27 @@ impl AzureObjectStore {
         let metadata = self.stat(uri).await?;
         self.size_cache.put(uri.to_string(), metadata.size).await;
         Ok(metadata.size)
+    }
+
+    fn download_mode_for_size(&self, object_size: u64) -> AzureDownloadMode {
+        if self.config.enable_range_engine {
+            return if object_size >= self.config.range_engine.min_split_size {
+                AzureDownloadMode::S3dlio
+            } else {
+                AzureDownloadMode::Sequential
+            };
+        }
+
+        match self.config.download_mode {
+            AzureDownloadMode::Auto if object_size < self.config.range_engine.min_split_size => {
+                AzureDownloadMode::Sequential
+            }
+            AzureDownloadMode::Auto => match self.config.auto_concurrent_engine {
+                AzureConcurrentEngine::AzureSdk => AzureDownloadMode::AzureSdk,
+                AzureConcurrentEngine::S3dlio => AzureDownloadMode::S3dlio,
+            },
+            mode => mode,
+        }
     }
 
     fn client_for_uri(uri: &str) -> Result<(AzureBlob, String, String, String)> {
@@ -2140,24 +2267,19 @@ impl ObjectStore for AzureObjectStore {
         // Get blob size from cache or stat (v0.9.10: cache optimization)
         let object_size = self.get_object_size(uri).await?;
 
-        // Use RangeEngine for large blobs if enabled
-        if self.config.enable_range_engine && object_size >= self.config.range_engine.min_split_size
-        {
-            debug!(
-                "Azure blob size {} >= threshold {}, using RangeEngine for {}",
-                object_size, self.config.range_engine.min_split_size, uri
-            );
-            return self.get_with_range_engine(uri, object_size).await;
+        match self.download_mode_for_size(object_size) {
+            AzureDownloadMode::S3dlio => self.get_with_range_engine(uri, object_size).await,
+            AzureDownloadMode::AzureSdk => {
+                cli.get_with_sdk_concurrency(
+                    &key,
+                    Some(self.config.sdk_download_concurrency),
+                    Some(self.config.sdk_download_part_size),
+                )
+                .await
+            }
+            AzureDownloadMode::Sequential => cli.get_sequential(&key, object_size).await,
+            AzureDownloadMode::Auto => unreachable!("auto mode must resolve before download"),
         }
-
-        // Simple sequential download for small blobs
-        debug!(
-            "Azure blob size {} < threshold {}, using simple download for {}",
-            object_size, self.config.range_engine.min_split_size, uri
-        );
-
-        let b = cli.get(&key).await?; // Bytes - return directly for zero-copy
-        Ok(b)
     }
 
     async fn get_range(&self, uri: &str, offset: u64, length: Option<u64>) -> Result<Bytes> {
@@ -3988,6 +4110,77 @@ pub async fn generic_download_objects_with_summary(
 // ─────────────────────────────────────────────────────────────────────────────
 // Unit tests for S3ObjectStore per-endpoint isolation
 // ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "backend-azure"))]
+mod azure_download_mode_tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_azure_download_modes_and_aliases() {
+        assert_eq!("auto".parse(), Ok(AzureDownloadMode::Auto));
+        assert_eq!("azure-sdk".parse(), Ok(AzureDownloadMode::AzureSdk));
+        assert_eq!("sdk".parse(), Ok(AzureDownloadMode::AzureSdk));
+        assert_eq!("s3dlio".parse(), Ok(AzureDownloadMode::S3dlio));
+        assert_eq!("range_engine".parse(), Ok(AzureDownloadMode::S3dlio));
+        assert_eq!("sequential".parse(), Ok(AzureDownloadMode::Sequential));
+        assert!("invalid".parse::<AzureDownloadMode>().is_err());
+    }
+
+    #[test]
+    fn auto_mode_uses_threshold_and_selected_concurrent_engine() {
+        let mut config = AzureConfig::default();
+        config.download_mode = AzureDownloadMode::Auto;
+        config.auto_concurrent_engine = AzureConcurrentEngine::AzureSdk;
+        config.range_engine.min_split_size = 32 * 1024 * 1024;
+        let store = AzureObjectStore::with_config(config.clone());
+
+        assert_eq!(
+            store.download_mode_for_size(1024),
+            AzureDownloadMode::Sequential
+        );
+        assert_eq!(
+            store.download_mode_for_size(32 * 1024 * 1024),
+            AzureDownloadMode::AzureSdk
+        );
+
+        config.auto_concurrent_engine = AzureConcurrentEngine::S3dlio;
+        let store = AzureObjectStore::with_config(config);
+        assert_eq!(
+            store.download_mode_for_size(32 * 1024 * 1024),
+            AzureDownloadMode::S3dlio
+        );
+    }
+
+    #[test]
+    fn explicit_mode_bypasses_auto_threshold() {
+        let config = AzureConfig {
+            download_mode: AzureDownloadMode::AzureSdk,
+            ..AzureConfig::default()
+        };
+        let store = AzureObjectStore::with_config(config);
+        assert_eq!(store.download_mode_for_size(1), AzureDownloadMode::AzureSdk);
+    }
+
+    #[test]
+    fn legacy_range_engine_switch_remains_compatible() {
+        let mut config = AzureConfig {
+            download_mode: AzureDownloadMode::AzureSdk,
+            enable_range_engine: true,
+            ..AzureConfig::default()
+        };
+        config.range_engine.min_split_size = 1024;
+        let store = AzureObjectStore::with_config(config);
+
+        assert_eq!(
+            store.download_mode_for_size(1023),
+            AzureDownloadMode::Sequential
+        );
+        assert_eq!(
+            store.download_mode_for_size(1024),
+            AzureDownloadMode::S3dlio
+        );
+    }
+}
 
 #[cfg(test)]
 mod s3_object_store_tests {


### PR DESCRIPTION
## Summary

- migrate Azure Blob support from pre-1.0 crates to stable `azure_core`, `azure_identity`, and `azure_storage_blob` 1.x APIs
- add configurable `auto`, Azure SDK, s3dlio RangeEngine, and sequential download strategies while preserving generic Azure-compatible endpoints
- retain zero-copy `Bytes` uploads, restore container lifecycle operations, and update Azure paging, ranges, and block APIs
- bump s3dlio to 0.9.114, Rust MSRV to 1.88, and document the new Azure environment controls

## Validation

- full Rust test suite: 783 passed, 0 failed
- Azure-enabled library suite: 421 passed, 0 failed, 1 credential-dependent live test ignored
- `cargo fmt --all -- --check`
- Clippy with `-D warnings`
- full-backend release build
- full CPython 3.12 and 3.13 wheels built successfully

Live Azure service correctness and performance validation remains pending until credentials are available.